### PR TITLE
Hotfix for failing on username/password auth.

### DIFF
--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -4,7 +4,7 @@ Client for DNSimple REST API
 http://developer.dnsimple.com/overview/
 """
 
-__version__ = '0.3.3'
+__version__ = '0.3.5'
 
 try:
     # Use stdlib's json if available (2.6+)
@@ -13,10 +13,23 @@ except ImportError:
     # Otherwise require extra simplejson library
     import simplejson as json
 try:
+    from base64 import encodebytes
+except ImportError:
+    from base64 import encodestring as encodebytes
+try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
 from requests import Request, Session, ConnectionError, HTTPError
+
+# To handle discrepancies between python 2 and 3 bytes.
+import sys
+if sys.version < '3':
+    def b(x):
+        return x
+else:
+    def b(x):
+        return x.encode()
 
 
 class DNSimpleException(Exception):
@@ -72,7 +85,8 @@ class DNSimple(object):
 
     @staticmethod
     def __get_auth_string(username, password):
-        return 'Basic {username}:{password}'.format(username=username, password=password)
+        encoded_string = encodebytes(b(username + ':' + password))[:-1].decode()
+        return "Basic {encoded_string}".format(encoded_string=encoded_string)
 
     def __get_auth_header(self):
         """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,23 @@
+__author__ = 'Chris Morgan'
+
+import unittest
+from dnsimple import DNSimple, DNSimpleException
+
+
+class AuthTestCase(unittest.TestCase):
+
+    def test_username_and_password_auth(self):
+        dns = DNSimple(username='chris.morgan@youngshand.com', password='dnsimple-python', sandbox=True)
+        self.assertTrue(type(dns.domains()) is list)
+
+    def test_email_and_api_token_auth(self):
+        dns = DNSimple(email='chris.morgan@youngshand.com', api_token='L0lkPizHnqVrsIyViLpB', sandbox=True)
+        self.assertTrue(type(dns.domains()) is list)
+
+    def test_config_auth(self):
+        dns = DNSimple(sandbox=True)
+        self.assertTrue(type(dns.domains()) is list)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I jumped the gun a little with removing base64 string encoding, this will fix auth and I've added some unit tests.

Passing on 2.78 and 3.41
