### PR TITLE
Run test suite against 3.6, 3.8, 3.9, pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 
 python:
+  - "3.6"
   - "3.8"
+  - "3.9"
+  - "pypy3"
 
 script:
   make test


### PR DESCRIPTION
This change extends the python versions we test against as part of best practices when maintaining a public package.