### PR TITLE
Evaluate status_code as integer in response checks

### DIFF
--- a/dnsimple/response.py
+++ b/dnsimple/response.py
@@ -50,7 +50,7 @@ class Response(object):
 
         self.add_data(obj, http_response)
 
-        if http_response.status_code != '204':
+        if http_response.status_code != 204:
             self.__class__.pagination = None if http_response.json().get('pagination') is None else Pagination(
                 http_response.json().get('pagination'))
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,8 +24,9 @@ class DNSimpleMockResponse(responses.Response):
                 headers[header_dic[0]] = header_dic[1]
 
         content = split_payload[len(split_payload) - 1]
+        status_code = int(split_payload[0].split(' ')[1])
         super(DNSimpleMockResponse, self).__init__(method, url, body=content, headers=headers,
-                                                   status=split_payload[0].split(' ')[1])
+                                                   status=status_code)
 
 
 class DNSimpleTest(unittest.TestCase):

--- a/tests/service/services_domains_test.py
+++ b/tests/service/services_domains_test.py
@@ -36,7 +36,7 @@ class TestName(DNSimpleTest):
                                            fixture_name='applyService/success'))
         response = self.services.apply_service(1010, 'example.com', 2)
 
-        self.assertEqual('204', response.http_response.status_code)
+        self.assertEqual(204, response.http_response.status_code)
 
     @responses.activate
     def test_unapply_service(self):
@@ -45,7 +45,7 @@ class TestName(DNSimpleTest):
                                            fixture_name='unapplyService/success'))
         response = self.services.unapply_service(1010, 'example.com', 2)
 
-        self.assertEqual('204', response.http_response.status_code)
+        self.assertEqual(204, response.http_response.status_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The status code was incorrectly serialized as a string in the test helpers. This has resulted in using strings to match if the status code is 204, which is inaccurate as the actual responses from the requests library would return an integer.

* status_code in responses is treated as an integer
* Update test helper to accurately serialize the response status code
* Tests are updated to reflect the change

Fixes https://github.com/dnsimple/dnsimple-python/issues/98