### PR TITLE
Add support for key-data interface creating delegation signer records

### DIFF
--- a/dnsimple/struct/delegation_signer_record.py
+++ b/dnsimple/struct/delegation_signer_record.py
@@ -22,6 +22,8 @@ class DelegationSignerRecord(Struct):
     """The digest type used."""
     keytag = None
     """The keytag for the associated DNSKEY."""
+    public_key = None
+    """The public key that references the corresponding DNSKEY record."""
     created_at = None
     """When the delegation signing record was created in DNSimple."""
     updated_at = None
@@ -35,21 +37,27 @@ class DelegationSignerRecord(Struct):
 class DelegationSignerRecordInput(dict):
     """Represents the input we send to create a domain delegation signer record"""
 
-    def __init__(self, algorithm, digest, digest_type, keytag):
+    def __init__(self, algorithm, digest=None, digest_type=None, keytag=None, public_key=None):
         """
         :param algorithm: str
             Required DNSSEC algorithms defined in
             http://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
             - pass the Number value as a string (i.e. '8').
         :param digest: str
-            Required The hexadecimal representation of the digest of the corresponding DNSKEY record.
+            Required if TLD requires DS data.
+            The hexadecimal representation of the digest of the corresponding DNSKEY record.
         :param digest_type: str
-            Required DNSSEC digest types defined in http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
+            Required if TLD requires DS data.
+            DNSSEC digest types defined in http://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
             - pass the Number value as string (i.e. '2').
         :param keytag: str
-            Required A keytag that references the corresponding DNSKEY record.
+            Required if TLD requires DS data.
+            A keytag that references the corresponding DNSKEY record.
+        :param public_key: str
+            Required if TLD requires KEY data.
+            The public key that references the corresponding DNSKEY record.
         """
-        dict.__init__(self, algorithm=algorithm, digest=digest, digest_type=digest_type, keytag=keytag)
+        dict.__init__(self, algorithm=algorithm, digest=digest, digest_type=digest_type, keytag=keytag, public_key=public_key)
 
     def to_json(self):
         return json.dumps(omitempty(self))

--- a/dnsimple/struct/tld.py
+++ b/dnsimple/struct/tld.py
@@ -25,6 +25,8 @@ class Tld(Struct):
     """True if DNSimple supports renewals for this TLD"""
     transfer_enabled = None
     """True if DNSimple supports inbound transfers for this TLD"""
+    dnssec_interface_type = None
+    """Type of data interface required for DNSSEC for this TLD"""
 
     def __init__(self, data):
         super().__init__(data)

--- a/tests/fixtures/v2/api/createDelegationSignerRecord/created.http
+++ b/tests/fixtures/v2/api/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/tests/fixtures/v2/api/getDelegationSignerRecord/success.http
+++ b/tests/fixtures/v2/api/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/tests/fixtures/v2/api/getTld/success.http
+++ b/tests/fixtures/v2/api/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/tests/fixtures/v2/api/listDelegationSignerRecords/success.http
+++ b/tests/fixtures/v2/api/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/tests/fixtures/v2/api/listTlds/success.http
+++ b/tests/fixtures/v2/api/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}

--- a/tests/service/domains_delegation_signer_records_test.py
+++ b/tests/service/domains_delegation_signer_records_test.py
@@ -31,9 +31,10 @@ class DomainsDelegationSignerRecordsTest(DNSimpleTest):
         responses.add(DNSimpleMockResponse(method=responses.POST,
                                            path='/1010/domains/1/ds_records',
                                            fixture_name='createDelegationSignerRecord/created'))
-        delegation_signer_record_input = DelegationSignerRecordInput('13',
-                                                                     '684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03',
-                                                                     '2', '2371')
+        delegation_signer_record_input = DelegationSignerRecordInput(algorithm='13',
+                                                                     digest='684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03',
+                                                                     digest_type='2',
+                                                                     keytag='2371')
 
         delegation_signer_record = self.domains.create_domain_delegation_signer_record(1010, 1,
                                                                                        delegation_signer_record_input).data
@@ -48,8 +49,12 @@ class DomainsDelegationSignerRecordsTest(DNSimpleTest):
                                            fixture_name='createDelegationSignerRecord/validation-error'))
 
         try:
-            self.domains.create_domain_delegation_signer_record(1010, 1,
-                                                                DelegationSignerRecordInput(None, None, None, None))
+            delegation_signer_record_input = DelegationSignerRecordInput(algorithm=None,
+                                                                         digest=None,
+                                                                         digest_type=None,
+                                                                         keytag=None)
+
+            self.domains.create_domain_delegation_signer_record(1010, 1, delegation_signer_record_input)
         except DNSimpleException as dnse:
             self.assertEqual(dnse.message, 'Validation failed')
             self.assertEqual("can't be blank", dnse.errors.get('algorithm')[0])
@@ -68,6 +73,7 @@ class DomainsDelegationSignerRecordsTest(DNSimpleTest):
         self.assertEqual('C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F', record.digest)
         self.assertEqual('2', record.digest_type)
         self.assertEqual('44620', record.keytag)
+        self.assertEqual(None, record.public_key)
         self.assertEqual('2017-03-03T13:49:58Z', record.created_at)
         self.assertEqual('2017-03-03T13:49:58Z', record.updated_at)
 

--- a/tests/service/tlds_test.py
+++ b/tests/service/tlds_test.py
@@ -33,7 +33,7 @@ class TldsTest(DNSimpleTest):
                                            path='/tlds?sort=tld:asc',
                                            fixture_name='listTlds/success'))
         self.tlds.list_tlds(sort='tld:asc')
-    
+
     @responses.activate
     def test_get_tld(self):
         responses.add(DNSimpleMockResponse(method=responses.GET,
@@ -50,7 +50,8 @@ class TldsTest(DNSimpleTest):
         self.assertTrue(tld.registration_enabled)
         self.assertTrue(tld.renewal_enabled)
         self.assertTrue(tld.transfer_enabled)
-        
+        self.assertEqual(tld.dnssec_interface_type, 'ds')
+
     @responses.activate
     def test_get_tld_extended_attributes(self):
         responses.add(DNSimpleMockResponse(method=responses.GET,


### PR DESCRIPTION
This PR:
* Updates the fixtures from [dnsimple-developer repo](https://github.com/dnsimple/dnsimple-developer/tree/main/fixtures/v2/api) to reflect the latest changes to our DNSSEC-related APIs.
* Adds new fields to affected structs.
* Updates documentation on affected endpoints.
* Updates some tests to make more clear what data is being passed in.

I was able to verify the changes by enabling DNSSEC on one of our testing .BE domains.