### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USER }}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,41 +69,6 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
     git push origin --tags
     ```
 
-## Generating distribution packages
-
-```shell
-make package
-```
-
-You can also check if your distribution is ready to be uploaded like so:
-
-```shell
-make test_package
-```
-
-## Uploading the distribution packages
-
-### 1. TestPyPi
-
-Run
-
-```shell
-make test_upload_package
-```
-
-This will upload the package to the testpypi environment.
-After the package has been uploaded successfully you can move onto the next step.
-
-### 2. Live PyPi
-
-Run
-
-```shell
-make upload_package
-```
-
-This will upload the package to the live pypi index.
-
 ## Testing
 
 Submit unit tests for your changes. You can test your changes on your machine by [running the test suite](#testing).


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

- [x] add the PYPI_USER to the secrets
- [x] add the PYPI_API_TOKEN to the secrets