### PR TITLE
Remove __class__ on contact attach_attributes_to

### DIFF
--- a/dnsimple/struct/contact.py
+++ b/dnsimple/struct/contact.py
@@ -46,7 +46,7 @@ class Contact(dict):
     """When the contact was last updated in DNSimple"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)
         dict.__init__(self, label=self.label, first_name=self.first_name, last_name=self.last_name,
                       job_title=self.job_title, organization_name=self.organization_name, email=self.email,
                       phone=self.phone, fax=self.fax, address1=self.address1, address2=self.address2, city=self.city,

--- a/tests/service/contacts_test.py
+++ b/tests/service/contacts_test.py
@@ -18,6 +18,8 @@ class ContactsTest(DNSimpleTest):
 
         self.assertEqual(2, len(contacts))
         self.assertIsInstance(contacts[0], Contact)
+        self.assertEqual(1, contacts[0].id)
+        self.assertEqual(2, contacts[1].id)
 
     @responses.activate
     def test_list_contacts_supports_pagination(self):


### PR DESCRIPTION
When calling list_contacts function from the contacts service returns a list of all of the same contacts.

For example (I changed my contact id to 12345 for the example):

>>> contact_list = client.contacts.list_contacts(account_id)
>>> for contact in contact_list.data:
...     print(contact.id)
...
12345
12345
12345
>>>
The contact struct gets overwritten when it is created.
