### PR TITLE
Fix attach_attributes_to call from class init

### DIFF
--- a/dnsimple/response.py
+++ b/dnsimple/response.py
@@ -92,4 +92,4 @@ class Pagination(object):
     """The total number of pages available given the current per_page value"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)

--- a/dnsimple/struct/contact.py
+++ b/dnsimple/struct/contact.py
@@ -46,7 +46,7 @@ class Contact(dict):
     """When the contact was last updated in DNSimple"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)
         dict.__init__(self, label=self.label, first_name=self.first_name, last_name=self.last_name,
                       job_title=self.job_title, organization_name=self.organization_name, email=self.email,
                       phone=self.phone, fax=self.fax, address1=self.address1, address2=self.address2, city=self.city,

--- a/dnsimple/struct/template.py
+++ b/dnsimple/struct/template.py
@@ -26,7 +26,7 @@ class Template(dict):
     """When the template was last updated in DNSimple"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)
         dict.__init__(self, id=self.id, account_id=self.account_id, name=self.name, sid=self.sid,
                       description=self.description, created_at=self.created_at, updated_at=self.updated_at)
 

--- a/dnsimple/struct/template_record.py
+++ b/dnsimple/struct/template_record.py
@@ -30,7 +30,7 @@ class TemplateRecord(dict):
     """When the template record was last updated in DNSimple"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)
         dict.__init__(self, id=self.id, template_id=self.template_id, name=self.name, content=self.content,
                       ttl=self.ttl, type=self.type, priority=self.priority, created_at=self.created_at,
                       updated_at=self.updated_at)

--- a/dnsimple/struct/webhook.py
+++ b/dnsimple/struct/webhook.py
@@ -16,7 +16,7 @@ class Webhook(dict):
     """The callback URL"""
 
     def __init__(self, data):
-        attach_attributes_to(self.__class__, data)
+        attach_attributes_to(self, data)
         dict.__init__(self, id=self.id, url=self.url)
 
     def to_json(self):

--- a/tests/service/contacts_test.py
+++ b/tests/service/contacts_test.py
@@ -18,6 +18,8 @@ class ContactsTest(DNSimpleTest):
 
         self.assertEqual(2, len(contacts))
         self.assertIsInstance(contacts[0], Contact)
+        self.assertEqual(1, contacts[0].id)
+        self.assertEqual(2, contacts[1].id)
 
     @responses.activate
     def test_list_contacts_supports_pagination(self):

--- a/tests/service/template_records_test.py
+++ b/tests/service/template_records_test.py
@@ -16,6 +16,8 @@ class TemplateRecordsTest(DNSimpleTest):
 
         self.assertEqual(2, len(records))
         self.assertIsInstance(records[0], TemplateRecord)
+        self.assertEqual(296, records[0].id)
+        self.assertEqual(298, records[1].id)
 
     @responses.activate
     def test_list_template_records_supports_pagination(self):

--- a/tests/service/templates_test.py
+++ b/tests/service/templates_test.py
@@ -17,6 +17,8 @@ class TemplatesTest(DNSimpleTest):
 
         self.assertEqual(2, len(templates))
         self.assertIsInstance(templates[0], Template)
+        self.assertEqual(1, templates[0].id)
+        self.assertEqual(2, templates[1].id)
 
     @responses.activate
     def test_list_templates_supports_pagination(self):

--- a/tests/service/webhooks_test.py
+++ b/tests/service/webhooks_test.py
@@ -16,6 +16,8 @@ class WebhooksTest(DNSimpleTest):
 
         self.assertEqual(2, len(webhooks))
         self.assertIsInstance(webhooks[0], Webhook)
+        self.assertEqual(1, webhooks[0].id)
+        self.assertEqual(2, webhooks[1].id)
 
     @responses.activate
     def test_list_webhooks_supports_sorting(self):


### PR DESCRIPTION
The `attach_attributes_to` function in `dnsimple.extra` is called in the `__init__` a few structs. The argument for `cls` passed through is `self.__class__`. This causes the class to be overwritten when multiple are created from the `return_list_of` in `response`.

Eg.
```
contact_list = client.contacts.list_contacts(account_id)
for contact in contact_list.data:
... print(contact.id)
...
12345
12345
12345
```

The classes affected are as follows:
- contacts
- webhook
- template_record
- template
- pagination

I have added tests for all classes listed except for pagination. There is only ever a single pagination object so a test is not relevant but making the way that `attach_attribute_to` consistent between classes is ideal.

Thanks for all of your help.