### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/dnsimple/service/certificates.py
+++ b/dnsimple/service/certificates.py
@@ -1,5 +1,5 @@
 from dnsimple.response import Response
-from dnsimple.struct import Certificate, CertificateBundle, CertificatePurchase, CertificateRenewal
+from dnsimple.struct import Certificate, CertificateBundle, CertificatePurchase, CertificateRenewal, LetsencryptCertificateInput
 
 
 class Certificates(object):
@@ -86,7 +86,7 @@ class Certificates(object):
         response = self.client.get(f'/{account_id}/domains/{domain}/certificates/{certificate_id}/private_key')
         return Response(response, CertificateBundle)
 
-    def purchase_letsencrypt_certificate(self, account_id, domain, certificate_input):
+    def purchase_letsencrypt_certificate(self, account_id, domain, certificate_input = LetsencryptCertificateInput()):
         """
         Purchase a Let's Encrypt certificate
 

--- a/dnsimple/struct/certificate.py
+++ b/dnsimple/struct/certificate.py
@@ -2,6 +2,7 @@ import json
 from dataclasses import dataclass
 
 import omitempty
+import warnings
 
 from dnsimple.struct import Struct
 
@@ -60,8 +61,11 @@ class CertificateBundle(Struct):
 
 
 class LetsencryptCertificateInput(dict):
-    def __init__(self, contact_id, auto_renew=None, name=None, alternate_names=None):
-        dict.__init__(self, contact_id=contact_id, auto_renew=auto_renew, name=name, alternate_names=alternate_names)
+    def __init__(self, contact_id=None, auto_renew=None, name=None, alternate_names=None):
+        dict.__init__(self, auto_renew=auto_renew, name=name, alternate_names=alternate_names)
+        if contact_id is not None:
+            warnings.warn("DEPRECATION WARNING: LetsencryptCertificateInput#contact_id is deprecated and will be ignored.")
+
 
     def to_json(self):
         return json.dumps(omitempty(self))

--- a/dnsimple/struct/certificate.py
+++ b/dnsimple/struct/certificate.py
@@ -64,7 +64,7 @@ class LetsencryptCertificateInput(dict):
     def __init__(self, contact_id=None, auto_renew=None, name=None, alternate_names=None):
         dict.__init__(self, auto_renew=auto_renew, name=name, alternate_names=alternate_names)
         if contact_id is not None:
-            warnings.warn("DEPRECATION WARNING: LetsencryptCertificateInput#contact_id is deprecated and will be ignored.")
+            warnings.warn("DEPRECATION WARNING: LetsencryptCertificateInput#contact_id is deprecated and its value is ignored and will be removed in the next major version.")
 
 
     def to_json(self):


### PR DESCRIPTION
We no longer require a contact_id to be provided to be able to purchase a Lets Encrypt certificate.

This one is a little trickier than other clients because of the the way we build the attributes to be used to purchase a LetsEncrypt certificate in `LetsencryptCertificateInput`. I have added a deprecation warning, while trying not to introduce any breaking changes. 