### PR TITLE
Ensures that the CI check is passing before releasing the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdownlint-cli:
     name: Lint markdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-   branches: [ main ]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
-# When changing the name apply the changes in the ./release.yml file
 name: CI
 
 on:
   push:
+   branches: [ main ]
   pull_request:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   markdownlint-cli:
+    name: Lint markdown
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -20,6 +20,7 @@ jobs:
           config_file: ".markdownlint.yaml"
 
   yamllint:
+    name: Lint YAML
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -27,10 +28,12 @@ jobs:
       - name: Run YAML Lint
         uses: actionshub/yamllint@main
 
-  build:
-    needs: [markdownlint-cli, yamllint]
+  test:
     runs-on: ubuntu-latest
-    name: Python ${{ matrix.python-version }}
+    name: Test Python ${{ matrix.python-version }}
+    needs:
+      - markdownlint-cli
+      - yamllint
     strategy:
       matrix:
         python-version:
@@ -50,7 +53,7 @@ jobs:
     if: always()
     name: Post Workflow Status To Slack
     needs:
-      - build
+      - test
     runs-on: ubuntu-latest
     steps:
       - name: Slack Workflow Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    name: Test Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }}
     needs:
       - markdownlint-cli
       - yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
----
-name: ci
+# When changing the name apply the changes in the ./release.yml file
+name: CI
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: 'refs/heads/main'
-          check-name: 'CI'
+          running-workflow-name: 'Publish to PyPI'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+          allowed-conclusions: success
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,17 @@ jobs:
         with:
           python-version: '3.8.5'
 
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+      # - name: Install dependencies
+      #   run: python -m pip install -r requirements.txt
 
-      - name: Upgrade setuptools
-        run: python -m pip install --upgrade pip setuptools wheel
+      # - name: Upgrade setuptools
+      #   run: python -m pip install --upgrade pip setuptools wheel
 
-      - name: Build package
-        run: python setup.py sdist bdist_wheel
+      # - name: Build package
+      #   run: python setup.py sdist bdist_wheel
 
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish distribution to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,17 @@ jobs:
         with:
           python-version: '3.8.5'
 
-      # - name: Install dependencies
-      #   run: python -m pip install -r requirements.txt
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
 
-      # - name: Upgrade setuptools
-      #   run: python -m pip install --upgrade pip setuptools wheel
+      - name: Upgrade setuptools
+        run: python -m pip install --upgrade pip setuptools wheel
 
-      # - name: Build package
-      #   run: python setup.py sdist bdist_wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
 
-      # - name: Publish distribution to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
----
 name: release
 
 on:
@@ -11,6 +10,14 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: 'refs/heads/main'
+          check-name: 'CI'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
       - uses: actions/checkout@v2
 
       - name: Set up Python


### PR DESCRIPTION
This PR ensures that the CI check is passing before releasing the package.

The selected approach is it use the Checks API via a community action [wait-on-check](https://github.com/marketplace/actions/wait-on-check). The action would check the default branch in our case that being **main**, and if the CI check has not yet passed it will hold the workflow execution until a result is out for the check and it can either fail or pass.

The following configuration is used for the Checks action:

```yaml
        uses: lewagon/wait-on-check-action@v1.0.0
        with:
          ref: 'refs/heads/main'
          running-workflow-name: 'Publish to PyPI'
          repo-token: ${{ secrets.GITHUB_TOKEN }}
          wait-interval: 10
          allowed-conclusions: success
```
* Default branch ref is hard coded
* `running-workflow-name` is used with the current workflow name, which means that we expect all other checks to pass before continuing.
* We use a wait interval of 10 seconds between checks.
* We only consider `success` as an allowed conclusion for the check, in order to continue execution.