### PR TITLE
Exceptions print their error message

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python 3.9.0
+python 3.10.0

--- a/dnsimple/exceptions.py
+++ b/dnsimple/exceptions.py
@@ -16,4 +16,4 @@ class DNSimpleException(Exception):
     def __str__(self):
         if self.errors is None:
             return self.message
-        return f'{self.message} -> {"".join(self.errors, ",")}'
+        return f'{self.message}: {"".join(self.errors, ",")}'

--- a/dnsimple/exceptions.py
+++ b/dnsimple/exceptions.py
@@ -1,4 +1,19 @@
 class DNSimpleException(Exception):
+    """
+    Root Exception raised for errors in the client.
+
+    :param message: str
+        The raw response from the server
+    :param errors: array[str]
+        An array of error messages
+    """
+
     def __init__(self, message=None, errors=None):
         self.message = message
         self.errors = errors
+        super().__init__(self.message)
+
+    def __str__(self):
+        if self.errors is None:
+            return self.message
+        return f'{self.message} -> {"".join(self.errors, ",")}'


### PR DESCRIPTION
Exception class initializes `super` and overrides `__str__` method. Previously the exception was not initialized correctly and the message was never printed as it normally should, this means that when reading stack traces, the developer would not see the reason why the exception was raised.

Belongs to #209 

Exception with errors:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/dnsimple-python/dnsimple/service/zones.py", line 154, in create_record
    return Response(response, ZoneRecord)
  File "/dnsimple-python/dnsimple/response.py", line 43, in __init__
    raise DNSimpleException(message=message, errors=errors)
dnsimple.exceptions.DNSimpleException: Validation failed: content
>>>
```

Exception with empty errors:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/dnsimple-python/dnsimple/service/zones.py", line 154, in create_record
    return Response(response, ZoneRecord)
  File "/dnsimple-python/dnsimple/response.py", line 43, in __init__
    raise DNSimpleException(message=message, errors=errors)
dnsimple.exceptions.DNSimpleException: Validation failed
>>>
```