### PR TITLE
Expose all information available in error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- CHANGED:
+  - Rename exceptions `errors` field to `attribute_errors`
+  - Added `reason`, `status` and `response` fields to exceptions
+  - Updates the exception string serialization format
+
 ## 2.6.0
 
 - CHANGED:

--- a/dnsimple/exceptions.py
+++ b/dnsimple/exceptions.py
@@ -4,16 +4,30 @@ class DNSimpleException(Exception):
 
     :param message: str
         The raw response from the server
-    :param errors: array[str]
-        An array of error messages
+    :param attribute_errors: dict
+        A dict of attribute error
+    :param http_response: requests.Response
+        HTTP response object
     """
 
-    def __init__(self, message=None, errors=None):
+    def __init__(self, message=None, attribute_errors=None, http_response=None):
         self.message = message
-        self.errors = errors
-        super().__init__(self.message)
+        self.attribute_errors = attribute_errors
+        self.status = None
+        self.reason = None
+        self.response = None
+
+        if http_response is not None:
+            self.reason = http_response.reason
+            self.status = http_response.status_code
+            self.response = http_response
 
     def __str__(self):
-        if self.errors is None:
-            return self.message
-        return f'{self.message}: {"".join(self.errors, ",")}'
+        """Custom error messages for exception"""
+        error_message = "({0})\n"\
+                        "Reason: {1}\n".format(self.status, self.reason)
+
+        if self.response is not None:
+            error_message += "HTTP response body: {0}\n".format(self.response.text)
+
+        return error_message

--- a/dnsimple/response.py
+++ b/dnsimple/response.py
@@ -36,11 +36,14 @@ class Response(object):
             When the server responds with an error code
         """
         if int(http_response.status_code) in range(400, 504):
-            message = http_response.json().get('message')
-            errors = None
-            if http_response.json().get('errors'):
-                errors = http_response.json().get('errors')
-            raise DNSimpleException(message=message, errors=errors)
+            if http_response.text != '':
+                message = http_response.json().get('message')
+                attribute_errors = None
+                if http_response.json().get('errors'):
+                    attribute_errors = http_response.json().get('errors')
+                raise DNSimpleException(message=message, attribute_errors=attribute_errors, http_response=http_response)
+
+            raise DNSimpleException(http_response=http_response)
 
         self.__class__.http_response = http_response
         self.__class__.headers = self.__class__.http_response.headers

--- a/dnsimple/response.py
+++ b/dnsimple/response.py
@@ -38,9 +38,7 @@ class Response(object):
         if int(http_response.status_code) in range(400, 504):
             if http_response.text != '':
                 message = http_response.json().get('message')
-                attribute_errors = None
-                if http_response.json().get('errors'):
-                    attribute_errors = http_response.json().get('errors')
+                attribute_errors = http_response.json().get('errors')
                 raise DNSimpleException(message=message, attribute_errors=attribute_errors, http_response=http_response)
 
             raise DNSimpleException(http_response=http_response)

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -1,0 +1,64 @@
+import unittest
+
+import responses
+
+from dnsimple import DNSimpleException
+from dnsimple.response import Response
+from dnsimple.struct import Domain
+from tests.helpers import DNSimpleTest, DNSimpleMockResponse
+
+
+class ExceptionTest(DNSimpleTest):
+    @responses.activate
+    def test_bad_request_exception(self):
+        responses.add(DNSimpleMockResponse(method=responses.POST,
+                                           path='/1010/domains',
+                                           fixture_name='validation-error'))
+        try:
+            self.domains.create_domain(1010, 'example-beta.com')
+        except DNSimpleException as ex:
+            self.assertEqual(ex.status, 400)
+            self.assertEqual(ex.reason, 'Bad Request')
+            self.assertEqual(ex.message, 'Validation failed')
+            self.assertEqual(ex.attribute_errors, {
+              'address1': ["can't be blank"],
+              'city': ["can't be blank"],
+              'country': ["can't be blank"],
+              'email': ["can't be blank", 'is an invalid email address'],
+              'first_name': ["can't be blank"],
+              'last_name': ["can't be blank"],
+              'phone': ["can't be blank", 'is probably not a phone number'],
+              'postal_code': ["can't be blank"],
+              'state_province': ["can't be blank"]
+            })
+            self.assertEqual(str(ex), '(400)\nReason: Bad Request\nHTTP response body: {0}\n'.format(ex.response.text))
+
+    @responses.activate
+    def test_not_found_exception(self):
+        responses.add(DNSimpleMockResponse(method=responses.POST,
+                                           path='/1010/domains',
+                                           fixture_name='notfound-domain'))
+        try:
+            self.domains.create_domain(1010, 'example-beta.com')
+        except DNSimpleException as ex:
+            self.assertEqual(ex.status, 404)
+            self.assertEqual(ex.reason, 'Not Found')
+            self.assertEqual(ex.message, 'Domain `0` not found')
+            self.assertEqual(ex.attribute_errors, None)
+            self.assertEqual(str(ex), '(404)\nReason: Not Found\nHTTP response body: {"message":"Domain `0` not found"}\n')
+
+    @responses.activate
+    def test_no_body_exception(self):
+        responses.add(DNSimpleMockResponse(method=responses.POST,
+                                           path='/1010/domains',
+                                           fixture_name='method-not-allowed'))
+        try:
+            self.domains.create_domain(1010, 'example-beta.com')
+        except DNSimpleException as ex:
+            self.assertEqual(ex.status, 405)
+            self.assertEqual(ex.reason, 'Method Not Allowed')
+            self.assertEqual(ex.message, None)
+            self.assertEqual(ex.attribute_errors, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/service/domains_delegation_signer_records_test.py
+++ b/tests/service/domains_delegation_signer_records_test.py
@@ -57,7 +57,7 @@ class DomainsDelegationSignerRecordsTest(DNSimpleTest):
             self.domains.create_domain_delegation_signer_record(1010, 1, delegation_signer_record_input)
         except DNSimpleException as dnse:
             self.assertEqual(dnse.message, 'Validation failed')
-            self.assertEqual("can't be blank", dnse.errors.get('algorithm')[0])
+            self.assertEqual("can't be blank", dnse.attribute_errors.get('algorithm')[0])
 
     @responses.activate
     def test_get_domain_delegation_signer_record(self):

--- a/tests/service/registrar_test.py
+++ b/tests/service/registrar_test.py
@@ -113,7 +113,7 @@ class RegistrarTest(DNSimpleTest):
             self.registrar.transfer_domain(1010, 'ruby.codes', DomainTransferRequest(2, 'TheAuthCode'))
         except DNSimpleException as dnse:
             self.assertEqual('Validation failed', dnse.message)
-            self.assertEqual('You must provide an authorization code for the domain', dnse.errors['base'][0])
+            self.assertEqual('You must provide an authorization code for the domain', dnse.attribute_errors['base'][0])
 
     @responses.activate
     def test_transfer_domain_error(self):
@@ -166,7 +166,7 @@ class RegistrarTest(DNSimpleTest):
             self.registrar.renew_domain(1010, 'example.com', DomainRenewRequest(period=1))
         except DNSimpleException as dnse:
             self.assertEqual('example.com may not be renewed at this time', dnse.message)
-        
+
     @responses.activate
     def test_transfer_domain_out(self):
         responses.add(DNSimpleMockResponse(method=responses.POST,


### PR DESCRIPTION
Our error responses sometimes include an `errors` entry with details about errors on the attributes of the specific resource. We handle those and other HTTP errors via `DNSimpleException`, but we were only considering the message, and the errors handling them in an unsafe way.

This PR:
  - Renames exceptions `errors` field to `attribute_errors`
  - Safe handle of error responses that have no body
  - Added `reason`, `status` and `response` fields to exceptions
  - Updates the exception string serialization format