### PR TITLE
Deprecate errors attr with warning

### DIFF
--- a/dnsimple/exceptions.py
+++ b/dnsimple/exceptions.py
@@ -1,3 +1,5 @@
+import warnings
+
 class DNSimpleException(Exception):
     """
     Root Exception raised for errors in the client.
@@ -31,3 +33,9 @@ class DNSimpleException(Exception):
             error_message += "HTTP response body: {0}\n".format(self.response.text)
 
         return error_message
+
+    @property
+    def errors(self):
+        """Return the attribute errors"""
+        warnings.warn("DEPRECATION WARNING: errors is deprecated, use attribute_errors instead.")
+        return self.attribute_errors

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -60,5 +60,17 @@ class ExceptionTest(DNSimpleTest):
             self.assertEqual(ex.message, None)
             self.assertEqual(ex.attribute_errors, None)
 
+    @responses.activate
+    def test_backward_compat_errors_attr_exception(self):
+        responses.add(DNSimpleMockResponse(method=responses.POST,
+                                           path='/1010/domains',
+                                           fixture_name='validation-error'))
+        try:
+            self.domains.create_domain(1010, 'example-beta.com')
+        except DNSimpleException as ex:
+            self.assertIsNotNone(ex.attribute_errors)
+            self.assertIsNotNone(ex.errors)
+            self.assertEqual(ex.errors, ex.attribute_errors)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously in #340 the `errors` attribute of `DNSimpleException` was entirely removed introducing a breaking change. In favor of keeping things backward compatible and allowing users to update their code gradually, the `errors` attribute has been brought back with deprecation warnings.