### PR TITLE
Drop py as direct dependency as pytest vendors it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
-## 2.7.1
+## 2.8.0
 
 - CHANGED:
+  - Drop py as a dependency ([dnsimple/dnsimple-python#388](https://github.com/dnsimple/dnsimple-python/pull/388))
   - Dependency updates
 
 ## 2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ mypy-extensions==0.4.3
 omitempty==0.1.1
 packaging==21.3
 pluggy==1.0.0
-py==1.11.0
 pyparsing==3.0.9
 pytest==7.2.0
 requests==2.28.1


### PR DESCRIPTION
This PR fixes the security issue CVE-2022-42969. https://github.com/pytest-dev/py/issues/287#issuecomment-1290407715

The py package has been removed from the requirements as a direct dependency.