### PR TITLE
Implement signature_algorithm parameter for Let's Encrypt APIs

### DIFF
--- a/dnsimple/service/certificates.py
+++ b/dnsimple/service/certificates.py
@@ -1,5 +1,5 @@
 from dnsimple.response import Response
-from dnsimple.struct import Certificate, CertificateBundle, CertificatePurchase, CertificateRenewal, LetsencryptCertificateInput
+from dnsimple.struct import Certificate, CertificateBundle, CertificatePurchase, CertificateRenewal, LetsencryptCertificateInput, LetsencryptCertificateRenewalInput
 
 
 class Certificates(object):
@@ -131,7 +131,7 @@ class Certificates(object):
         response = self.client.post(f'/{account_id}/domains/{domain}/certificates/letsencrypt/{certificate_id}/issue')
         return Response(response, Certificate)
 
-    def purchase_letsencrypt_certificate_renewal(self, account_id, domain, certificate_id):
+    def purchase_letsencrypt_certificate_renewal(self, account_id, domain, certificate_id, certificate_renewal_input = LetsencryptCertificateRenewalInput()):
         """
         Purchase a Let's Encrypt certificate renewal.
 
@@ -147,7 +147,7 @@ class Certificates(object):
         :return: dnsimple.Response
             The certificate renewal
         """
-        response = self.client.post(f'/{account_id}/domains/{domain}/certificates/letsencrypt/{certificate_id}/renewals')
+        response = self.client.post(f'/{account_id}/domains/{domain}/certificates/letsencrypt/{certificate_id}/renewals', data=certificate_renewal_input.to_json())
         return Response(response, CertificateRenewal)
 
     def issue_letsencrypt_certificate_renewal(self, account_id, domain, certificate_id, certificate_renewal_id):

--- a/dnsimple/struct/__init__.py
+++ b/dnsimple/struct/__init__.py
@@ -1,7 +1,7 @@
 from dnsimple.struct.struct import Struct
 from dnsimple.struct.access_token import AccessToken
 from dnsimple.struct.account import Account
-from dnsimple.struct.certificate import Certificate, CertificateBundle, LetsencryptCertificateInput, CertificatePurchase, CertificateRenewal
+from dnsimple.struct.certificate import Certificate, CertificateBundle, LetsencryptCertificateInput, LetsencryptCertificateRenewalInput, CertificatePurchase, CertificateRenewal
 from dnsimple.struct.collaborator import Collaborator
 from dnsimple.struct.contact import Contact
 from dnsimple.struct.dnssec import Dnssec

--- a/dnsimple/struct/certificate.py
+++ b/dnsimple/struct/certificate.py
@@ -61,10 +61,19 @@ class CertificateBundle(Struct):
 
 
 class LetsencryptCertificateInput(dict):
-    def __init__(self, contact_id=None, auto_renew=None, name=None, alternate_names=None):
-        dict.__init__(self, auto_renew=auto_renew, name=name, alternate_names=alternate_names)
+    def __init__(self, contact_id=None, auto_renew=None, name=None, alternate_names=None, signature_algorithm=None):
+        dict.__init__(self, auto_renew=auto_renew, name=name, alternate_names=alternate_names, signature_algorithm=signature_algorithm)
         if contact_id is not None:
             warnings.warn("DEPRECATION WARNING: LetsencryptCertificateInput#contact_id is deprecated and its value is ignored and will be removed in the next major version.")
+
+
+    def to_json(self):
+        return json.dumps(omitempty(self))
+
+
+class LetsencryptCertificateRenewalInput(dict):
+    def __init__(self, auto_renew=None, signature_algorithm=None):
+        dict.__init__(self, auto_renew=auto_renew, signature_algorithm=signature_algorithm)
 
 
     def to_json(self):

--- a/tests/service/certificates_test.py
+++ b/tests/service/certificates_test.py
@@ -4,7 +4,7 @@ import responses
 import datetime
 
 from dnsimple.response import Pagination
-from dnsimple.struct import Certificate, LetsencryptCertificateInput
+from dnsimple.struct import Certificate, LetsencryptCertificateInput, LetsencryptCertificateRenewalInput
 from tests.helpers import DNSimpleMockResponse, DNSimpleTest
 
 
@@ -174,7 +174,7 @@ class CertificatesTest(DNSimpleTest):
         responses.add(DNSimpleMockResponse(method=responses.POST,
                                            path='/1010/domains/example.com/certificates/letsencrypt/200/renewals',
                                            fixture_name='purchaseRenewalLetsencryptCertificate/success'))
-        renewal = self.certificates.purchase_letsencrypt_certificate_renewal(1010, 'example.com', 200).data
+        renewal = self.certificates.purchase_letsencrypt_certificate_renewal(1010, 'example.com', 200, LetsencryptCertificateRenewalInput(False, "RSA")).data
 
         self.assertIsInstance(renewal.id, int)
         self.assertIsInstance(renewal.old_certificate_id, int)


### PR DESCRIPTION
Add the signature_algorithm parameter for purchase_letsencrypt_certificate and purchase_letsencrypt_certificate_renewal APIs.