### PR TITLE
Unpin Python version and pin Ubuntu version in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Wait for tests to succeed
         uses: lewagon/wait-on-check-action@v1.3.1
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8.5'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: python -m pip install -r requirements.txt


### PR DESCRIPTION
We don't need to pin the Python version to `3.8.5` specifically. It's out of date and `ubuntu-22.04` doesn't have it (newer patch releases are available). We'll also pin our Ubuntu version to avoid unexpected versioning issues in the future.