### PR TITLE
Add support to activate and deactivate DNS services for a zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
+## main
+
+## 2.10.1 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Zones.activate_dns` to activate DNS services (resolution) for a zone. (dnsimple/dnsimple-python#432)
+- NEW: Added `Zones.deactivate_dns` to deactivate DNS services (resolution) for a zone. (dnsimple/dnsimple-python#432)
+
 ## 2.10.0
 
 - NEW:

--- a/dnsimple/service/domains.py
+++ b/dnsimple/service/domains.py
@@ -349,7 +349,7 @@ class Domains(object):
         :return: dnsimple.Response
             The newly created email forward under the domain in the account
         """
-        response = self.client.post(f'/{account_id}/domains/{domain}/email_forwards', data=json.dumps({'from': email_forwards_input.email_from, 'to': email_forwards_input.email_to}))
+        response = self.client.post(f'/{account_id}/domains/{domain}/email_forwards', data=json.dumps({'alias_name': email_forwards_input.email_from, 'destination_email': email_forwards_input.email_to}))
         return Response(response, EmailForward)
 
     def get_email_forward(self, account_id, domain, email_forward_id):

--- a/dnsimple/service/zones.py
+++ b/dnsimple/service/zones.py
@@ -12,6 +12,38 @@ class Zones(object):
     def __init__(self, client):
         self.client = client
 
+    def activate_dns(self, account_id, zone_name):
+        """
+        Activates DNS resolution for the zone in the account.
+
+        See https://developer.dnsimple.com/v2/zones/#activateZoneService
+
+        :param account_id: int
+            The account ID
+        :param zone_name:
+            The zone name
+
+        :return: dnsimple.Response
+        """
+        response = self.client.put(f'/{account_id}/zones/{zone_name}/activation')
+        return Response(response, Zone)
+
+    def deactivate_dns(self, account_id, zone_name):
+        """
+        Deactivates DNS resolution for the zone in the account.
+
+        See https://developer.dnsimple.com/v2/zones/#deactivateZoneService
+
+        :param account_id: int
+            The account ID
+        :param zone_name:
+            The zone name
+
+        :return: dnsimple.Response
+        """
+        response = self.client.delete(f'/{account_id}/zones/{zone_name}/activation')
+        return Response(response, Zone)
+
     def list_zones(self, account_id, filter=None, sort=None, page=None, per_page=None):
         """
         Lists the zones in the account.

--- a/tests/fixtures/v2/api/activateZoneService/success.http
+++ b/tests/fixtures/v2/api/activateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1691471963
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"fe6afd982459be33146933235343d51d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8e8ac535-9f46-4304-8440-8c68c30427c3
+X-Runtime: 0.176579
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/deactivateZoneService/success.http
+++ b/tests/fixtures/v2/api/deactivateZoneService/success.http
@@ -1,0 +1,16 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 08 Aug 2023 04:19:52 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1691471962
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"5f30a37d01b99bb9e620ef1bbce9a014"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: d2f7bba4-4c81-4818-81d2-c9bbe95f104e
+X-Runtime: 0.133278
+Strict-Transport-Security: max-age=63072000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/service/zones_test.py
+++ b/tests/service/zones_test.py
@@ -9,6 +9,34 @@ from tests.helpers import DNSimpleTest, DNSimpleMockResponse
 
 class ZonesTest(DNSimpleTest):
     @responses.activate
+    def test_activate_zone(self):
+        responses.add(DNSimpleMockResponse(method=responses.PUT,
+                                           path='/1010/zones/example.com/activation',
+                                           fixture_name='activateZoneService/success'))
+        zone = self.zones.activate_dns(1010, 'example.com').data
+
+        self.assertEqual(1, zone.id)
+        self.assertEqual(1010, zone.account_id)
+        self.assertEqual('example.com', zone.name)
+        self.assertFalse(zone.reverse)
+        self.assertEqual('2015-04-23T07:40:03Z', zone.created_at)
+        self.assertEqual('2015-04-23T07:40:03Z', zone.updated_at)
+
+    @responses.activate
+    def test_deactivate_zone(self):
+        responses.add(DNSimpleMockResponse(method=responses.DELETE,
+                                           path='/1010/zones/example.com/activation',
+                                           fixture_name='deactivateZoneService/success'))
+        zone = self.zones.deactivate_dns(1010, 'example.com').data
+
+        self.assertEqual(1, zone.id)
+        self.assertEqual(1010, zone.account_id)
+        self.assertEqual('example.com', zone.name)
+        self.assertFalse(zone.reverse)
+        self.assertEqual('2015-04-23T07:40:03Z', zone.created_at)
+        self.assertEqual('2015-04-23T07:40:03Z', zone.updated_at)
+
+    @responses.activate
     def test_list_zones(self):
         responses.add(DNSimpleMockResponse(method=responses.GET,
                                            path='/1010/zones',


### PR DESCRIPTION
This PR implements https://github.com/dnsimple/dnsimple-developer/pull/502 which allows for the management of DNS resolution for a particular zone.

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/3
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/2