### PR TITLE
Add support to create a registrant change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
-## 2.10.2 (Unreleased)
+## 2.11.0 (Unreleased)
 
 FEATURES:
 
-- NEW: Added `Registrar.create_registrant_change` to start a registrant change. (dnsimple/dnsimple-python#433)
+- NEW: Added `list_registrant_changes`, `create_registrant_change`, `check_registrant_change`, `get_registrant_change`, and `delete_registrant_change` APIs to manage registrant changes. (dnsimple/dnsimple-python#433)
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+## 2.10.2 (Unreleased)
+
+FEATURES:
+
+- NEW: Added `Registrar.create_registrant_change` to start a registrant change. (dnsimple/dnsimple-python#433)
+
 ## 2.10.1
 
 FEATURES:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
 
 1. Set the version in `./dnsimple/version.py` and `pyproject.toml`.
 
-    ```
+    ```python
     version = "$VERSION"
     ```
 

--- a/dnsimple/response.py
+++ b/dnsimple/response.py
@@ -51,7 +51,8 @@ class Response(object):
 
         self.add_data(obj, http_response)
 
-        if http_response.status_code != 204:
+        # TODO Check response body is not empty as workaround for bug where server sends empty response despite having Content-Type: application/json, causing parser to crash.
+        if http_response.status_code != 204 and http_response.text != '':
             self.__class__.pagination = None if http_response.json().get('pagination') is None else Pagination(
                 http_response.json().get('pagination'))
 

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -4,6 +4,7 @@ import warnings
 from dnsimple.response import Response
 from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, \
     VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice
+from dnsimple.struct.registrant import RegistrantChange
 
 
 class Registrar(object):
@@ -418,3 +419,28 @@ class Registrar(object):
         """
         response = self.client.post(f'/{account_id}/registrar/domains/{domain}/whois_privacy')
         return Response(response, WhoisPrivacyRenewal)
+
+    def create_registrant_change(self, account_id, domain, contact, extended_attributes):
+        """
+        Start a registrant change.
+
+        See https://developer.dnsimple.com/v2/registrar/#createRegistrantChange
+
+        :param account_id: int
+            The account ID
+        :param domain: int/str
+            The domain name or id
+        :param contact: int
+            The contact id
+        :param extended_attributes: dict
+            The extended attributes
+
+        :return: dnsimple.Response
+            The registrant change
+        """
+        response = self.client.post(f'/{account_id}/registrar/registrant_changes', json.dumps({
+            "domain_id": domain,
+            "contact_id": contact,
+            "extended_attributes": extended_attributes,
+        }))
+        return Response(response, RegistrantChange)

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -4,6 +4,7 @@ import warnings
 from dnsimple.response import Response
 from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, \
     RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice
+from dnsimple.struct.registrant import CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck
 
 
 class Registrar(object):
@@ -419,27 +420,77 @@ class Registrar(object):
         response = self.client.post(f'/{account_id}/registrar/domains/{domain}/whois_privacy')
         return Response(response, WhoisPrivacyRenewal)
 
-    def create_registrant_change(self, account_id, domain, contact, extended_attributes):
+
+    def list_registrant_changes(self, account: int):
         """
-        Start a registrant change.
+        List registrant changes in the account.
+
+        See https://developer.dnsimple.com/v2/registrar/#listRegistrantChanges
+
+        :param account:
+            The account id
+        """
+        response = self.client.get(f"/{account}/registrar/registrant_changes")
+        return Response(response, RegistrantChange)
+
+    def create_registrant_change(
+        self, account: int, input: CreateRegistrantChangeInput
+    ):
+        """
+        Start registrant change.
 
         See https://developer.dnsimple.com/v2/registrar/#createRegistrantChange
 
-        :param account_id: int
-            The account ID
-        :param domain: int/str
-            The domain name or id
-        :param contact: int
-            The contact id
-        :param extended_attributes: dict
-            The extended attributes
-
-        :return: dnsimple.Response
-            The registrant change
+        :param account:
+            The account id
         """
-        response = self.client.post(f'/{account_id}/registrar/registrant_changes', json.dumps({
-            "domain_id": domain,
-            "contact_id": contact,
-            "extended_attributes": extended_attributes,
-        }))
+        response = self.client.post(f"/{account}/registrar/registrant_changes", data=input.to_json())
         return Response(response, RegistrantChange)
+
+    def check_registrant_change(
+        self, account: int, input: CheckRegistrantChangeInput
+    ):
+        """
+        Retrieves the requirements of a registrant change.
+
+        See https://developer.dnsimple.com/v2/registrar/#checkRegistrantChange
+
+        :param account:
+            The account id
+        """
+        response = self.client.post(f"/{account}/registrar/registrant_changes/check")
+        return Response(response, RegistrantChangeCheck)
+
+    def get_registrant_change(self, account: int, registrantchange: int):
+        """
+        Retrieves the details of an existing registrant change.
+
+        See https://developer.dnsimple.com/v2/registrar/#getRegistrantChange
+
+        :param account:
+            The account id
+        :param registrantchange:
+            The registrant change id
+        """
+        response = self.client.get(
+            f"/{account}/registrar/registrant_changes/{registrantchange}"
+        )
+        return Response(response, RegistrantChange)
+
+    def delete_registrant_change(self, account: int, registrantchange: int):
+        """
+        Cancel an ongoing registrant change from the account.
+
+        See https://developer.dnsimple.com/v2/registrar/#deleteRegistrantChange
+
+        :param account:
+            The account id
+        :param registrantchange:
+            The registrant change id
+        """
+        response = self.client.delete(
+            f"/{account}/registrar/registrant_changes/{registrantchange}"
+        )
+        return Response(
+            response,
+        )

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -3,8 +3,7 @@ import warnings
 
 from dnsimple.response import Response
 from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, \
-    VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice
-from dnsimple.struct.registrant import RegistrantChange
+    RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice
 
 
 class Registrar(object):

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -419,7 +419,7 @@ class Registrar(object):
         return Response(response, WhoisPrivacyRenewal)
 
 
-    def list_registrant_changes(self, account: int):
+    def list_registrant_changes(self, account: int, options=None):
         """
         List registrant changes in the account.
 
@@ -427,8 +427,10 @@ class Registrar(object):
 
         :param account:
             The account id
+        :param options:
+            Optional query parameters to filter and sort the results.
         """
-        response = self.client.get(f"/{account}/registrar/registrant_changes")
+        response = self.client.get(f"/{account}/registrar/registrant_changes", params=options)
         return Response(response, RegistrantChange)
 
     def create_registrant_change(

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -2,9 +2,7 @@ import json
 import warnings
 
 from dnsimple.response import Response
-from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, \
-    RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice
-from dnsimple.struct.registrant import CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck
+from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice, CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck
 
 
 class Registrar(object):

--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -458,7 +458,7 @@ class Registrar(object):
         :param account:
             The account id
         """
-        response = self.client.post(f"/{account}/registrar/registrant_changes/check")
+        response = self.client.post(f"/{account}/registrar/registrant_changes/check", data=input.to_json())
         return Response(response, RegistrantChangeCheck)
 
     def get_registrant_change(self, account: int, registrantchange: int):

--- a/dnsimple/struct/__init__.py
+++ b/dnsimple/struct/__init__.py
@@ -15,7 +15,7 @@ from dnsimple.struct.domain_renewal import DomainRenewal, DomainRenewRequest
 from dnsimple.struct.domain_transfer import DomainTransfer, DomainTransferRequest
 from dnsimple.struct.domain_push import DomainPush
 from dnsimple.struct.email_forward import EmailForward, EmailForwardInput
-from dnsimple.struct.registrant import RegistrantChange, CheckRegistrantChangeInput, CreateRegistrantChangeInput, ExtendedAttribute, ExtendedAttributeOption, RegistrantChangeCheck
+from dnsimple.struct.registrant import RegistrantChange, CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck
 from dnsimple.struct.service import Service
 from dnsimple.struct.template import Template
 from dnsimple.struct.template_record import TemplateRecord

--- a/dnsimple/struct/__init__.py
+++ b/dnsimple/struct/__init__.py
@@ -15,7 +15,7 @@ from dnsimple.struct.domain_renewal import DomainRenewal, DomainRenewRequest
 from dnsimple.struct.domain_transfer import DomainTransfer, DomainTransferRequest
 from dnsimple.struct.domain_push import DomainPush
 from dnsimple.struct.email_forward import EmailForward, EmailForwardInput
-from dnsimple.struct.registrant import RegistrantChange
+from dnsimple.struct.registrant import RegistrantChange, CheckRegistrantChangeInput, CreateRegistrantChangeInput, ExtendedAttribute, ExtendedAttributeOption, RegistrantChangeCheck
 from dnsimple.struct.service import Service
 from dnsimple.struct.template import Template
 from dnsimple.struct.template_record import TemplateRecord

--- a/dnsimple/struct/__init__.py
+++ b/dnsimple/struct/__init__.py
@@ -15,6 +15,7 @@ from dnsimple.struct.domain_renewal import DomainRenewal, DomainRenewRequest
 from dnsimple.struct.domain_transfer import DomainTransfer, DomainTransferRequest
 from dnsimple.struct.domain_push import DomainPush
 from dnsimple.struct.email_forward import EmailForward, EmailForwardInput
+from dnsimple.struct.registrant import RegistrantChange
 from dnsimple.struct.service import Service
 from dnsimple.struct.template import Template
 from dnsimple.struct.template_record import TemplateRecord

--- a/dnsimple/struct/registrant.py
+++ b/dnsimple/struct/registrant.py
@@ -1,90 +1,90 @@
 from dataclasses import dataclass
 from dnsimple.struct import Struct
-from typing import Dict, List, Literal, Union
 import json
+import omitempty
 
 
 @dataclass
 class RegistrantChange(Struct):
-    id: int
-    account_id: int
-    contact_id: int
-    domain_id: int
-    state: Literal["new", "pending", "cancelling", "cancelled", "completed"]
-    extended_attributes: Dict[str, str]
-    registry_owner_change: bool
-    irt_lock_lifted_by: str
-    created_at: str
-    updated_at: str
+    id = None
+    account_id = None
+    contact_id = None
+    domain_id = None
+    state = None
+    extended_attributes = None
+    registry_owner_change = None
+    irt_lock_lifted_by = None
+    created_at = None
+    updated_at = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))
 
 
 @dataclass
 class RegistrantChangeCheck(Struct):
-    contact_id: int
-    domain_id: int
-    extended_attributes: List["ExtendedAttribute"]
-    registry_owner_change: bool
+    contact_id = None
+    domain_id = None
+    extended_attributes = None
+    registry_owner_change = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))
 
 
 @dataclass
 class ExtendedAttribute(Struct):
-    name: str
-    description: str
-    required: bool
-    options: List["ExtendedAttributeOption"]
+    name = None
+    description = None
+    required = None
+    options = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))
 
 
 @dataclass
 class ExtendedAttributeOption(Struct):
-    title: str
-    value: str
-    description: str
+    title = None
+    value = None
+    description = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))
 
 
 @dataclass
 class CreateRegistrantChangeInput(Struct):
-    domain_id: Union[str, int]
-    contact_id: Union[str, int]
-    extended_attributes: Dict[str, str]
+    domain_id = None
+    contact_id = None
+    extended_attributes = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))
 
 
 @dataclass
 class CheckRegistrantChangeInput(Struct):
-    domain_id: Union[str, int]
-    contact_id: Union[str, int]
+    domain_id = None
+    contact_id = None
 
     def __init__(self, data):
         super().__init__(data)
 
     def to_json(self):
-        return json.dumps(self)
+        return json.dumps(omitempty(self))

--- a/dnsimple/struct/registrant.py
+++ b/dnsimple/struct/registrant.py
@@ -20,9 +20,6 @@ class RegistrantChange(Struct):
     def __init__(self, data):
         super().__init__(data)
 
-    def to_json(self):
-        return json.dumps(omitempty(self))
-
 
 @dataclass
 class RegistrantChangeCheck(Struct):
@@ -34,57 +31,23 @@ class RegistrantChangeCheck(Struct):
     def __init__(self, data):
         super().__init__(data)
 
-    def to_json(self):
-        return json.dumps(omitempty(self))
-
 
 @dataclass
-class ExtendedAttribute(Struct):
-    name = None
-    description = None
-    required = None
-    options = None
-
-    def __init__(self, data):
-        super().__init__(data)
+class CreateRegistrantChangeInput(dict):
+    def __init__(self, domain_id = None, contact_id = None, extended_attributes = None):
+        super().__init__(domain_id=domain_id, contact_id=contact_id, extended_attributes=extended_attributes)
 
     def to_json(self):
         return json.dumps(omitempty(self))
 
 
 @dataclass
-class ExtendedAttributeOption(Struct):
-    title = None
-    value = None
-    description = None
-
-    def __init__(self, data):
-        super().__init__(data)
-
-    def to_json(self):
-        return json.dumps(omitempty(self))
-
-
-@dataclass
-class CreateRegistrantChangeInput(Struct):
-    domain_id = None
-    contact_id = None
-    extended_attributes = None
-
-    def __init__(self, data):
-        super().__init__(data)
-
-    def to_json(self):
-        return json.dumps(omitempty(self))
-
-
-@dataclass
-class CheckRegistrantChangeInput(Struct):
+class CheckRegistrantChangeInput(dict):
     domain_id = None
     contact_id = None
 
-    def __init__(self, data):
-        super().__init__(data)
+    def __init__(self, domain_id = None, contact_id = None):
+        super().__init__(domain_id=domain_id, contact_id=contact_id)
 
     def to_json(self):
         return json.dumps(omitempty(self))

--- a/dnsimple/struct/registrant.py
+++ b/dnsimple/struct/registrant.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from dnsimple.struct import Struct
+
+
+@dataclass
+class RegistrantChange(Struct):
+    """Represents a registrant change."""
+    
+    id = None
+    type = None
+    account_id = None
+    contact_id = None
+    domain_id = None
+    state = None
+    extended_attributes = None
+    registry_owner_change = None
+    irt_lock_lifted_by = None
+    created_at = None
+    updated_at = None

--- a/dnsimple/struct/registrant.py
+++ b/dnsimple/struct/registrant.py
@@ -1,19 +1,90 @@
 from dataclasses import dataclass
 from dnsimple.struct import Struct
+from typing import Dict, List, Literal, Union
+import json
 
 
 @dataclass
 class RegistrantChange(Struct):
-    """Represents a registrant change."""
-    
-    id = None
-    type = None
-    account_id = None
-    contact_id = None
-    domain_id = None
-    state = None
-    extended_attributes = None
-    registry_owner_change = None
-    irt_lock_lifted_by = None
-    created_at = None
-    updated_at = None
+    id: int
+    account_id: int
+    contact_id: int
+    domain_id: int
+    state: Literal["new", "pending", "cancelling", "cancelled", "completed"]
+    extended_attributes: Dict[str, str]
+    registry_owner_change: bool
+    irt_lock_lifted_by: str
+    created_at: str
+    updated_at: str
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)
+
+
+@dataclass
+class RegistrantChangeCheck(Struct):
+    contact_id: int
+    domain_id: int
+    extended_attributes: List["ExtendedAttribute"]
+    registry_owner_change: bool
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)
+
+
+@dataclass
+class ExtendedAttribute(Struct):
+    name: str
+    description: str
+    required: bool
+    options: List["ExtendedAttributeOption"]
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)
+
+
+@dataclass
+class ExtendedAttributeOption(Struct):
+    title: str
+    value: str
+    description: str
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)
+
+
+@dataclass
+class CreateRegistrantChangeInput(Struct):
+    domain_id: Union[str, int]
+    contact_id: Union[str, int]
+    extended_attributes: Dict[str, str]
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)
+
+
+@dataclass
+class CheckRegistrantChangeInput(Struct):
+    domain_id: Union[str, int]
+    contact_id: Union[str, int]
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    def to_json(self):
+        return json.dumps(self)

--- a/tests/fixtures/v2/api/checkRegistrantChange/success.http
+++ b/tests/fixtures/v2/api/checkRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:09:40 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2395
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"cef1e7d85d0b9bfd25e81b812891d34f"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: 5b0d8bfb-7b6a-40b5-a079-b640fd817e34
+x-runtime: 3.066249
+strict-transport-security: max-age=63072000
+
+{"data":{"domain_id":101,"contact_id":101,"extended_attributes":[],"registry_owner_change":true}}

--- a/tests/fixtures/v2/api/createRegistrantChange/success.http
+++ b/tests/fixtures/v2/api/createRegistrantChange/success.http
@@ -1,0 +1,14 @@
+HTTP/2 202 
+server: nginx
+date: Tue, 22 Aug 2023 11:11:00 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2394
+x-ratelimit-reset: 1692705339
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: 26bf7ff9-2075-42b0-9431-1778c825b6b0
+x-runtime: 3.408950
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/tests/fixtures/v2/api/deleteRegistrantChange/success.http
+++ b/tests/fixtures/v2/api/deleteRegistrantChange/success.http
@@ -1,0 +1,13 @@
+HTTP/2 201 
+server: nginx
+date: Tue, 22 Aug 2023 11:14:44 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2391
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+cache-control: no-cache
+x-request-id: b123e1f0-aa70-4abb-95cf-34f377c83ef4
+x-runtime: 0.114839
+strict-transport-security: max-age=63072000
+

--- a/tests/fixtures/v2/api/getRegistrantChange/success.http
+++ b/tests/fixtures/v2/api/getRegistrantChange/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:13:58 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2392
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"76c5d4c7579b754b94a42ac7fa37a901"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: e910cd08-3f9c-4da4-9986-50dbe9c3bc55
+x-runtime: 0.022006
+strict-transport-security: max-age=63072000
+
+{"data":{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}}

--- a/tests/fixtures/v2/api/listRegistrantChanges/success.http
+++ b/tests/fixtures/v2/api/listRegistrantChanges/success.http
@@ -1,0 +1,15 @@
+HTTP/2 200 
+server: nginx
+date: Tue, 22 Aug 2023 11:12:49 GMT
+content-type: application/json; charset=utf-8
+x-ratelimit-limit: 2400
+x-ratelimit-remaining: 2393
+x-ratelimit-reset: 1692705338
+x-work-with-us: Love automation? So do we! https://dnsimple.com/jobs
+etag: W/"0049703ea058b06346df4c0e169eac29"
+cache-control: max-age=0, private, must-revalidate
+x-request-id: fd0334ce-414a-4872-8889-e548e0b1410c
+x-runtime: 0.030759
+strict-transport-security: max-age=63072000
+
+{"data":[{"id":101,"account_id":101,"domain_id":101,"contact_id":101,"state":"new","extended_attributes":{},"registry_owner_change":true,"irt_lock_lifted_by":null,"created_at":"2017-02-03T17:43:22Z","updated_at":"2017-02-03T17:43:22Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/tests/service/registrar_registrant_test.py
+++ b/tests/service/registrar_registrant_test.py
@@ -1,0 +1,156 @@
+from dataclasses import asdict
+import unittest
+
+import responses
+
+from dnsimple.struct.registrant import (
+    CheckRegistrantChangeInput,
+    CreateRegistrantChangeInput,
+    RegistrantChange,
+    RegistrantChangeCheck,
+)
+from tests.helpers import DNSimpleMockResponse, DNSimpleTest
+
+
+class RegistrarRegistrantTest(DNSimpleTest):
+    @responses.activate
+    def test_check_registrant_change(self):
+        responses.add(
+            DNSimpleMockResponse(
+                method=responses.POST,
+                path="/1010/registrar/registrant_changes/check",
+                fixture_name="checkRegistrantChange/success",
+            )
+        )
+        res = self.registrar.check_registrant_change(
+            1010,
+            CheckRegistrantChangeInput(
+                domain_id=101,
+                contact_id=101,
+            ),
+        ).data
+
+        self.assertEqual(
+            res,
+            RegistrantChangeCheck(
+                {
+                    "domain_id": 101,
+                    "contact_id": 101,
+                    "extended_attributes": [],
+                    "registry_owner_change": True,
+                }
+            ),
+        )
+
+    @responses.activate
+    def test_create_registrant_change(self):
+        responses.add(
+            DNSimpleMockResponse(
+                method=responses.POST,
+                path="/1010/registrar/registrant_changes",
+                fixture_name="createRegistrantChange/success",
+            )
+        )
+        res = self.registrar.create_registrant_change(
+            1010,
+            CreateRegistrantChangeInput(
+                contact_id=101,
+                domain_id=101,
+                extended_attributes={},
+            ),
+        ).data
+
+        self.assertEqual(
+            res,
+            RegistrantChange(
+                {
+                    "id": 101,
+                    "account_id": 101,
+                    "domain_id": 101,
+                    "contact_id": 101,
+                    "state": "new",
+                    "extended_attributes": {},
+                    "registry_owner_change": True,
+                    "irt_lock_lifted_by": None,
+                    "created_at": "2017-02-03T17:43:22Z",
+                    "updated_at": "2017-02-03T17:43:22Z",
+                }
+            ),
+        )
+
+    @responses.activate
+    def test_delete_registrant_change(self):
+        responses.add(
+            DNSimpleMockResponse(
+                method=responses.DELETE,
+                path="/1010/registrar/registrant_changes/101",
+                fixture_name="deleteRegistrantChange/success",
+            )
+        )
+        res = self.registrar.delete_registrant_change(1010, 101).data
+
+        self.assertEqual(res, None)
+
+    @responses.activate
+    def test_get_registrant_change(self):
+        responses.add(
+            DNSimpleMockResponse(
+                method=responses.GET,
+                path="/1010/registrar/registrant_changes/101",
+                fixture_name="getRegistrantChange/success",
+            )
+        )
+        res = self.registrar.get_registrant_change(1010, 101).data
+
+        self.assertEqual(
+            res,
+            RegistrantChange(
+                {
+                    "id": 101,
+                    "account_id": 101,
+                    "domain_id": 101,
+                    "contact_id": 101,
+                    "state": "new",
+                    "extended_attributes": {},
+                    "registry_owner_change": True,
+                    "irt_lock_lifted_by": None,
+                    "created_at": "2017-02-03T17:43:22Z",
+                    "updated_at": "2017-02-03T17:43:22Z",
+                }
+            ),
+        )
+
+    @responses.activate
+    def test_list_registrant_changes(self):
+        responses.add(
+            DNSimpleMockResponse(
+                method=responses.GET,
+                path="/1010/registrar/registrant_changes",
+                fixture_name="listRegistrantChanges/success",
+            )
+        )
+        res = self.registrar.list_registrant_changes(1010).data
+
+        self.assertEqual(
+            res,
+            [
+                RegistrantChange(
+                    {
+                        "id": 101,
+                        "account_id": 101,
+                        "domain_id": 101,
+                        "contact_id": 101,
+                        "state": "new",
+                        "extended_attributes": {},
+                        "registry_owner_change": True,
+                        "irt_lock_lifted_by": None,
+                        "created_at": "2017-02-03T17:43:22Z",
+                        "updated_at": "2017-02-03T17:43:22Z",
+                    }
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces 5 new endpoints that are part of the domain contact management API that was introduced in https://github.com/dnsimple/dnsimple-developer/pull/501.

The following endpoints have been added:
- **listRegistrantChanges**: GET `/{account}/registrar/registrant_changes`
- **createRegistrantChange**: POST `/{account}/registrar/registrant_changes`
- **checkRegistrantChange**: POST `/{account}/registrar/registrant_changes/check`
- **getRegistrantChange**: GET `/{account}/registrar/registrant_changes/{registrantchange}`
- **deleteRegistrantChange**: DELETE `/{account}/registrar/registrant_changes/{registrantchange}`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1729