### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `secondary`, `last_transferred_at`, `active` to `Zone` (dnsimple/dnsimple-python)
+
 ## 2.12.0
 
 FEATURES:

--- a/dnsimple/struct/zone.py
+++ b/dnsimple/struct/zone.py
@@ -19,6 +19,12 @@ class Zone(Struct):
     """The zone name"""
     reverse = None
     """True if the zone is a reverse zone"""
+    secondary = None
+    """True if the zone is a secondary zone"""
+    last_transferred_at = None
+    """When the zone was last transferred"""
+    active = None
+    """True if the zone is active"""
     created_at = None
     """When the zone was created in DNSimple"""
     updated_at = None

--- a/tests/fixtures/v2/api/getZone/success.http
+++ b/tests/fixtures/v2/api/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/tests/fixtures/v2/api/listZones/success.http
+++ b/tests/fixtures/v2/api/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/tests/service/zones_test.py
+++ b/tests/service/zones_test.py
@@ -19,6 +19,7 @@ class ZonesTest(DNSimpleTest):
         self.assertEqual(1010, zone.account_id)
         self.assertEqual('example.com', zone.name)
         self.assertFalse(zone.reverse)
+        self.assertTrue(zone.active)
         self.assertEqual('2015-04-23T07:40:03Z', zone.created_at)
         self.assertEqual('2015-04-23T07:40:03Z', zone.updated_at)
 
@@ -33,6 +34,7 @@ class ZonesTest(DNSimpleTest):
         self.assertEqual(1010, zone.account_id)
         self.assertEqual('example.com', zone.name)
         self.assertFalse(zone.reverse)
+        self.assertFalse(zone.active)
         self.assertEqual('2015-04-23T07:40:03Z', zone.created_at)
         self.assertEqual('2015-04-23T07:40:03Z', zone.updated_at)
 
@@ -77,6 +79,9 @@ class ZonesTest(DNSimpleTest):
         self.assertEqual(1010, zone.account_id)
         self.assertEqual('example-alpha.com', zone.name)
         self.assertFalse(zone.reverse)
+        self.assertFalse(zone.secondary)
+        self.assertEqual(None, zone.last_transferred_at)
+        self.assertTrue(zone.active)
         self.assertEqual('2015-04-23T07:40:03Z', zone.created_at)
         self.assertEqual('2015-04-23T07:40:03Z', zone.updated_at)
 


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `secondary`, `last_transferred_at`, `active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17