### PR TITLE
Add restore domain endpoints

### DIFF
--- a/dnsimple/service/registrar.py
+++ b/dnsimple/service/registrar.py
@@ -2,7 +2,7 @@ import json
 import warnings
 
 from dnsimple.response import Response
-from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice, CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck, DomainTransferLock
+from dnsimple.struct import DomainCheck, DomainPremiumPrice, DomainRegistration, DomainTransfer, DomainRenewal, DomainRestore, RegistrantChange, VanityNameServer, WhoisPrivacy, WhoisPrivacyRenewal, DomainPrice, CheckRegistrantChangeInput, CreateRegistrantChangeInput, RegistrantChangeCheck, DomainTransferLock
 
 
 class Registrar(object):
@@ -535,3 +535,44 @@ class Registrar(object):
         """
         response = self.client.delete(f'/{account}/registrar/domains/{domain}/transfer_lock')
         return Response(response, DomainTransferLock)
+
+    def restore_domain(self, account_id, domain, request):
+        """
+        Restores an expired domain name registered with DNSimple.
+
+        Your account must be active for this command to complete successfully. You will be automatically charged the
+        restore fee upon successful renewal, so please be careful with this command.
+
+        See https://developer.dnsimple.com/v2/registrar/#restoreDomain
+
+        :param account_id: int
+            The account ID
+        :param domain: str
+            The domain name
+        :param request: dnsimple.struct.DomainRestoreRequest
+            The restore options
+
+        :return: dnsimple.Request
+            The domain restore
+        """
+        response = self.client.post(f'/{account_id}/registrar/domains/{domain}/restores', request.to_json())
+        return Response(response, DomainRestore)
+
+    def get_domain_restore(self, account_id, domain, domain_restore):
+        """
+        Get the details of an existing domain restore.
+
+        https://developer.dnsimple.com/v2/registrar/#getDomainRestore
+
+        :param account_id: int
+            The account ID
+        :param domain: str
+            The domain name
+        :param domain_restore: int
+            The domain restore ID
+
+        :return: dnsimple.Response
+            The domain restore
+        """
+        response = self.client.get(f'/{account_id}/registrar/domains/{domain}/restores/{domain_restore}')
+        return Response(response, DomainRestore)

--- a/dnsimple/struct/__init__.py
+++ b/dnsimple/struct/__init__.py
@@ -13,6 +13,7 @@ from dnsimple.struct.domain_premium_price import DomainPremiumPrice, DomainPremi
 from dnsimple.struct.domain_price import DomainPrice
 from dnsimple.struct.domain_registration import DomainRegistration, DomainRegistrationRequest
 from dnsimple.struct.domain_renewal import DomainRenewal, DomainRenewRequest
+from dnsimple.struct.domain_restore import DomainRestore, DomainRestoreRequest
 from dnsimple.struct.domain_transfer import DomainTransfer, DomainTransferRequest
 from dnsimple.struct.domain_transfer_lock import DomainTransferLock
 from dnsimple.struct.domain_push import DomainPush

--- a/dnsimple/struct/domain_restore.py
+++ b/dnsimple/struct/domain_restore.py
@@ -1,0 +1,34 @@
+import json
+from dataclasses import dataclass
+
+import omitempty
+
+from dnsimple.struct import Struct
+
+
+class DomainRestoreRequest(dict):
+    """DomainRestoreRequest represents the attributes you can pass to a restore API request."""
+    def __init__(self, premium_price=None):
+        dict.__init__(self, premium_price=premium_price)
+
+    def to_json(self):
+        return json.dumps(omitempty(self))
+
+
+@dataclass
+class DomainRestore(Struct):
+
+    """Represents the result of a domain restore call."""
+    id = None
+    """The domain registration ID in DNSimple"""
+    domain_id = None
+    """The associated domain ID"""
+    state = None
+    """The state of the restore"""
+    created_at = None
+    """When the domain restore was created in DNSimple"""
+    updated_at = None
+    """When the domain restore was last updated in DNSimple"""
+
+    def __init__(self, data):
+        super().__init__(data)

--- a/tests/fixtures/v2/api/getDomainRestore/success.http
+++ b/tests/fixtures/v2/api/getDomainRestore/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"state":"restored","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}

--- a/tests/fixtures/v2/api/restoreDomain/success.http
+++ b/tests/fixtures/v2/api/restoreDomain/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"state":"new","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/tests/service/registrar_test.py
+++ b/tests/service/registrar_test.py
@@ -3,7 +3,7 @@ import unittest
 import responses
 
 from dnsimple import DNSimpleException
-from dnsimple.struct import DomainPremiumPriceOptions, DomainTransferRequest, DomainRenewRequest
+from dnsimple.struct import DomainPremiumPriceOptions, DomainTransferRequest, DomainRenewRequest, DomainRestoreRequest
 from dnsimple.struct.domain_registration import DomainRegistrationRequest
 from tests.helpers import DNSimpleMockResponse, DNSimpleTest
 
@@ -205,6 +205,31 @@ class RegistrarTest(DNSimpleTest):
                                            fixture_name='authorizeDomainTransferOut/success'))
         self.registrar.transfer_domain_out(1010, 'example.com')
 
+    @responses.activate
+    def test_restore_domain(self):
+        responses.add(DNSimpleMockResponse(method=responses.POST,
+                                           path='/1010/registrar/domains/ruby.codes/restores',
+                                           fixture_name='restoreDomain/success'))
+        domain_restore = self.registrar.restore_domain(1010, 'ruby.codes', DomainRestoreRequest()).data
+
+        self.assertEqual(1, domain_restore.id)
+        self.assertEqual(999, domain_restore.domain_id)
+        self.assertEqual('new', domain_restore.state)
+        self.assertEqual('2016-12-09T19:46:45Z', domain_restore.created_at)
+        self.assertEqual('2016-12-09T19:46:45Z', domain_restore.updated_at)
+
+    @responses.activate
+    def test_get_domain_restore(self):
+        responses.add(DNSimpleMockResponse(method=responses.GET,
+                                           path='/1010/registrar/domains/bingo.pizza/restores/1',
+                                           fixture_name='getDomainRestore/success'))
+        domain_restore = self.registrar.get_domain_restore(1010, 'bingo.pizza', 1).data
+
+        self.assertEqual(domain_restore.id, 1)
+        self.assertEqual(domain_restore.domain_id, 999)
+        self.assertEqual(domain_restore.state, "restored")
+        self.assertEqual(domain_restore.created_at, "2016-12-09T19:46:45Z")
+        self.assertEqual(domain_restore.updated_at, "2016-12-12T19:46:45Z")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-business/issues/1654.

## Description
This adds two methods to the library: (1) `RestoreDomain` and (2) `GetDomainRestore`. The API endpoint implementation is in https://github.com/dnsimple/dnsimple-app/pull/25863.