### PR TITLE
Update `EmailForward` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project uses [Semantic Versioning 2.0.0](http://semver.org/).
 
 ## main
 
+- NEW: Added `alias_email` and `destination_email` to `EmailForward`
+- CHANGED: Deprecated `email_from` and `email_to` fields in `EmailForward`
+- CHANGED: Aligned `EmailForwardInput` constructor param names with current endpoint definition
+
 ## 3.0.0
 
 - CHANGED: Drop support for Python < 3.12

--- a/dnsimple/service/domains.py
+++ b/dnsimple/service/domains.py
@@ -349,7 +349,7 @@ class Domains(object):
         :return: dnsimple.Response
             The newly created email forward under the domain in the account
         """
-        response = self.client.post(f'/{account_id}/domains/{domain}/email_forwards', data=json.dumps({'alias_name': email_forwards_input.email_from, 'destination_email': email_forwards_input.email_to}))
+        response = self.client.post(f'/{account_id}/domains/{domain}/email_forwards', data=json.dumps({'alias_name': email_forwards_input.alias_name, 'destination_email': email_forwards_input.destination_email}))
         return Response(response, EmailForward)
 
     def get_email_forward(self, account_id, domain, email_forward_id):

--- a/dnsimple/struct/email_forward.py
+++ b/dnsimple/struct/email_forward.py
@@ -13,6 +13,8 @@ class EmailForward(Struct):
     """The "local part" of the originating email address. Anything to the left of the @ symbol"""
     email_to = None
     """The full email address to forward to"""
+    alias_email = None
+    destination_email = None
     created_at = None
     """When the email forward was created in DNSimple"""
     updated_at = None

--- a/dnsimple/struct/email_forward.py
+++ b/dnsimple/struct/email_forward.py
@@ -28,6 +28,7 @@ class EmailForward(Struct):
 
 @dataclass
 class EmailForwardInput(object):
-    def __init__(self, email_from, email_to):
-        self.email_from = email_from
-        self.email_to = email_to
+    def __init__(self, alias_name, destination_email):
+        self.alias_name = alias_name
+        self.destination_email = destination_email
+

--- a/dnsimple/struct/email_forward.py
+++ b/dnsimple/struct/email_forward.py
@@ -10,9 +10,9 @@ class EmailForward(Struct):
     domain_id = None
     """The associated domain ID"""
     email_from = None
-    """The "local part" of the originating email address. Anything to the left of the @ symbol"""
+    """DEPRECATED: The "local part" of the originating email address. Anything to the left of the @ symbol"""
     email_to = None
-    """The full email address to forward to"""
+    """DEPRECATED: The full email address to forward to"""
     alias_email = None
     destination_email = None
     created_at = None
@@ -22,8 +22,8 @@ class EmailForward(Struct):
 
     def __init__(self, data):
         super().__init__(data)
-        setattr(self, 'email_from', data['from'])
-        setattr(self, 'email_to', self.to)
+        setattr(self, 'email_from', data['alias_email'])
+        setattr(self, 'email_to', data['destination_email'])
 
 
 @dataclass

--- a/tests/fixtures/v2/api/createEmailForward/created.http
+++ b/tests/fixtures/v2/api/createEmailForward/created.http
@@ -2,6 +2,7 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4772

--- a/tests/fixtures/v2/api/getEmailForward/success.http
+++ b/tests/fixtures/v2/api/getEmailForward/success.http
@@ -2,6 +2,7 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
+Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4766

--- a/tests/fixtures/v2/api/listEmailForwards/success.http
+++ b/tests/fixtures/v2/api/listEmailForwards/success.http
@@ -1,16 +1,16 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:07:19 GMT
+Date: Fri, 17 May 2024 09:07:28 GMT
 Content-Type: application/json; charset=utf-8
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1454596043
-ETag: W/"3f10aae0cf0f0b81bdb4f58786ee1750"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4748
+X-RateLimit-Reset: 1715936948
+X-WORK-WITH-US: Love automation? So do we! https://dnsimple.com/jobs
+ETag: W/"a5eed9a071f03e10fc67001ccc647a94"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 6e3aa9d0-cb95-4186-93b0-630da372de86
-X-Runtime: 0.026287
-Strict-Transport-Security: max-age=31536000
+X-Request-Id: e42df983-a8a5-4123-8c74-fb89ab934aba
+X-Runtime: 0.025456
+Strict-Transport-Security: max-age=63072000
 
-{"data":[{"id":17702,"domain_id":228963,"from":".*@a-domain.com","to":"jane.smith@example.com","created_at":"2016-02-04T13:59:29Z","updated_at":"2016-02-04T13:59:29Z"},{"id":17703,"domain_id":228963,"from":"john@a-domain.com","to":"john@example.com","created_at":"2016-02-04T14:07:13Z","updated_at":"2016-02-04T14:07:13Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":24809,"domain_id":235146,"alias_email":".*@a-domain.com","destination_email":"jane.smith@example.com","created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":".*@a-domain.com","to":"jane.smith@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/tests/service/domains_email_forwards_test.py
+++ b/tests/service/domains_email_forwards_test.py
@@ -15,7 +15,7 @@ class DomainsEmailForwardsTest(DNSimpleTest):
                                            fixture_name='listEmailForwards/success'))
         email_forwards = self.domains.list_email_forwards(1010, 'example.com').data
 
-        self.assertEqual(2, len(email_forwards))
+        self.assertEqual(1, len(email_forwards))
         self.assertIsInstance(email_forwards[0], EmailForward)
         self.assertEqual('.*@a-domain.com', email_forwards[0].email_from)
 

--- a/tests/service/domains_email_forwards_test.py
+++ b/tests/service/domains_email_forwards_test.py
@@ -46,6 +46,8 @@ class DomainsEmailForwardsTest(DNSimpleTest):
         self.assertIsInstance(email_forward.domain_id, int)
         self.assertEqual('example@dnsimple.xyz', email_forward.email_from)
         self.assertEqual('example@example.com', email_forward.email_to)
+        self.assertEqual('example@dnsimple.xyz', email_forward.alias_email)
+        self.assertEqual('example@example.com', email_forward.destination_email)
         self.assertIsInstance(datetime.datetime.strptime(email_forward.created_at, '%Y-%m-%dT%H:%M:%SZ'), datetime.datetime)
         self.assertIsInstance(datetime.datetime.strptime(email_forward.updated_at, '%Y-%m-%dT%H:%M:%SZ'), datetime.datetime)
 


### PR DESCRIPTION
See https://github.com/dnsimple/dnsimple-developer/issues/315 for reference

In this PR:
- Add `alias_email` and `destination_email` fields to `EmailForward`
- Deprecate `email_from` and `email_to` fields in `EmailForward
- Align `EmailForwardInput` constructor param names with current endpoint definition