### PR TITLE
Add `active` attribute in `EmailForward`

### DIFF
--- a/dnsimple/struct/email_forward.py
+++ b/dnsimple/struct/email_forward.py
@@ -15,6 +15,7 @@ class EmailForward(Struct):
     """DEPRECATED: The full email address to forward to"""
     alias_email = None
     destination_email = None
+    active = None
     created_at = None
     """When the email forward was created in DNSimple"""
     updated_at = None

--- a/tests/fixtures/v2/api/listEmailForwards/success.http
+++ b/tests/fixtures/v2/api/listEmailForwards/success.http
@@ -13,4 +13,4 @@ X-Request-Id: e42df983-a8a5-4123-8c74-fb89ab934aba
 X-Runtime: 0.025456
 Strict-Transport-Security: max-age=63072000
 
-{"data":[{"id":24809,"domain_id":235146,"alias_email":".*@a-domain.com","destination_email":"jane.smith@example.com","created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":".*@a-domain.com","to":"jane.smith@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24809,"domain_id":235146,"alias_email":"foo@a-domain.com","destination_email":"jane.smith@example.com","active":true,"created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":"foo@a-domain.com","to":"jane.smith@example.com"},{"id":24810,"domain_id":235146,"alias_email":"bar@a-domain.com","destination_email":"john.doe@example.com","active":false,"created_at":"2017-05-25T19:23:16Z","updated_at":"2017-05-25T19:23:16Z","from":"bar@a-domain.com","to":"john.doe@example.com"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/tests/service/domains_email_forwards_test.py
+++ b/tests/service/domains_email_forwards_test.py
@@ -15,9 +15,19 @@ class DomainsEmailForwardsTest(DNSimpleTest):
                                            fixture_name='listEmailForwards/success'))
         email_forwards = self.domains.list_email_forwards(1010, 'example.com').data
 
-        self.assertEqual(1, len(email_forwards))
+        self.assertEqual(2, len(email_forwards))
         self.assertIsInstance(email_forwards[0], EmailForward)
-        self.assertEqual('.*@a-domain.com', email_forwards[0].email_from)
+        self.assertEqual(24809, email_forwards[0].id)
+        self.assertEqual(235146, email_forwards[0].domain_id)
+        self.assertEqual('foo@a-domain.com', email_forwards[0].alias_email)
+        self.assertEqual("jane.smith@example.com", email_forwards[0].destination_email)
+        self.assertEqual(True, email_forwards[0].active)
+        self.assertIsInstance(email_forwards[1], EmailForward)
+        self.assertEqual(24810, email_forwards[1].id)
+        self.assertEqual(235146, email_forwards[1].domain_id)
+        self.assertEqual('bar@a-domain.com', email_forwards[1].alias_email)
+        self.assertEqual("john.doe@example.com", email_forwards[1].destination_email)
+        self.assertEqual(False, email_forwards[1].active)
 
     @responses.activate
     def test_list_email_forwards_supports_sorting(self):


### PR DESCRIPTION
Fixes https://github.com/dnsimple/dnsimple-python/issues/453

This PR adds the new `active` attribute in the `EmailForward` struct to expose its value from DNSimple API's responses.