### PR TITLE
markdownlint: Align with other configs

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,3 @@
 ---
 default: true
 line-length: false
-no-missing-space-atx: false


### PR DESCRIPTION
Align with the other configs. There's an extra rule that it's not clear why it was set.