### PR TITLE
Allow empty string to represent apex records

### DIFF
--- a/dnsimple/struct/zone_record.py
+++ b/dnsimple/struct/zone_record.py
@@ -14,7 +14,12 @@ class ZoneRecordUpdateInput(dict):
         dict.__init__(self, name=name, content=content, ttl=ttl, priority=priority, regions=regions)
 
     def to_json(self):
-        return json.dumps(omitempty(self))
+        omitted = omitempty(self)
+
+        if self['name'] == '':
+            omitted['name'] = ''
+
+        return json.dumps(omitted)
 
 
 @dataclass
@@ -25,8 +30,12 @@ class ZoneRecordInput(dict):
         dict.__init__(self, name=name, type=type, content=content, ttl=ttl, priority=priority, regions=regions)
 
     def to_json(self):
-        return json.dumps(omitempty(self))
+        omitted = omitempty(self)
 
+        if self['name'] == '':
+            omitted['name'] = ''
+
+        return json.dumps(omitted)
 
 @dataclass
 class ZoneRecord(Struct):

--- a/tests/struct/zone_record_test.py
+++ b/tests/struct/zone_record_test.py
@@ -1,0 +1,32 @@
+import unittest
+
+from dnsimple.struct.zone_record import ZoneRecordInput, ZoneRecordUpdateInput
+from tests.helpers import DNSimpleTest, DNSimpleMockResponse
+
+class ZoneRecordTest(DNSimpleTest):
+    def test_zone_record_input_json_allows_empty_string_apex(self):
+        zone_record_input = ZoneRecordInput('', 'A', '127.0.0.1')
+
+        json = zone_record_input.to_json()
+        self.assertEqual('{"type": "A", "content": "127.0.0.1", "name": ""}', json)
+
+    def test_zone_record_input_json_rejects_none_apex(self):
+        zone_record_input = ZoneRecordInput(None, 'A', '127.0.0.1')
+
+        json = zone_record_input.to_json()
+        self.assertEqual('{"type": "A", "content": "127.0.0.1"}', json)
+
+    def test_zone_record_update_input_json_allows_empty_string_apex(self):
+        zone_record_input = ZoneRecordUpdateInput('', '127.0.0.1', 3600)
+
+        json = zone_record_input.to_json()
+        self.assertEqual('{"content": "127.0.0.1", "ttl": 3600, "name": ""}', json)
+
+    def test_zone_record_update_input_json_rejects_none_apex(self):
+        zone_record_input = ZoneRecordUpdateInput(None, '127.0.0.1', 3600)
+
+        json = zone_record_input.to_json()
+        self.assertEqual('{"content": "127.0.0.1", "ttl": 3600}', json)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/dnsimple/dnsimple-python/issues/451.

## Description
When creating a `ZoneRecordInput` and `ZoneRecordUpdateInput` with `name=''`, the `to_json()` command omits the `name` attribute because of the `omitempty` command. The `omitempty` [command](https://github.com/bfontaine/omitempty) removes empty strings by default.

This PR changes the behavior to allow a name with an empty string to be rendered by the `to_json` command. This name with an empty string represents an apex record.