### PR TITLE
Remove from and to from EmailForwards

### DIFF
--- a/dnsimple/struct/email_forward.py
+++ b/dnsimple/struct/email_forward.py
@@ -9,10 +9,6 @@ class EmailForward(Struct):
     """The email forward ID in DNSimple"""
     domain_id = None
     """The associated domain ID"""
-    email_from = None
-    """DEPRECATED: The "local part" of the originating email address. Anything to the left of the @ symbol"""
-    email_to = None
-    """DEPRECATED: The full email address to forward to"""
     alias_email = None
     destination_email = None
     active = None

--- a/tests/service/domains_email_forwards_test.py
+++ b/tests/service/domains_email_forwards_test.py
@@ -54,8 +54,6 @@ class DomainsEmailForwardsTest(DNSimpleTest):
                                                           EmailForwardInput('example@dnsimple.xyz', 'example@example.com')).data
         self.assertIsInstance(email_forward.id, int)
         self.assertIsInstance(email_forward.domain_id, int)
-        self.assertEqual('example@dnsimple.xyz', email_forward.email_from)
-        self.assertEqual('example@example.com', email_forward.email_to)
         self.assertEqual('example@dnsimple.xyz', email_forward.alias_email)
         self.assertEqual('example@example.com', email_forward.destination_email)
         self.assertIsInstance(datetime.datetime.strptime(email_forward.created_at, '%Y-%m-%dT%H:%M:%SZ'), datetime.datetime)


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.