### PR TITLE
Add support for trustee service in transfers

### DIFF
--- a/dnsimple/struct/domain_transfer.py
+++ b/dnsimple/struct/domain_transfer.py
@@ -9,10 +9,26 @@ from dnsimple.struct import Struct
 class DomainTransferRequest(dict):
     """DomainTransferRequest represents the attributes you can pass to a register API request."""
 
-    def __init__(self, registrant_id, auth_code, whois_privacy=False, auto_renew=False, extended_attributes=None,
-                 premium_price=None):
-        dict.__init__(self, registrant_id=registrant_id, auth_code=auth_code, whois_privacy=whois_privacy,
-                      auto_renew=auto_renew, extended_attributes=extended_attributes, premium_price=premium_price)
+    def __init__(
+        self,
+        registrant_id,
+        auth_code,
+        whois_privacy=False,
+        auto_renew=False,
+        extended_attributes=None,
+        premium_price=None,
+        trustee_service=None,
+    ):
+        dict.__init__(
+            self,
+            registrant_id=registrant_id,
+            auth_code=auth_code,
+            whois_privacy=whois_privacy,
+            auto_renew=auto_renew,
+            extended_attributes=extended_attributes,
+            premium_price=premium_price,
+            trustee_service=trustee_service,
+        )
 
     def to_json(self):
         return json.dumps(omitempty(self))
@@ -33,6 +49,8 @@ class DomainTransfer(Struct):
     """True if the domain auto-renew was requested"""
     whois_privacy = False
     """True if the domain WHOIS privacy was requested"""
+    trustee_service = False
+    """True if the domain Trustee service was requested"""
     created_at = None
     """When the domain transfer was created in DNSimple"""
     updated_at = None

--- a/tests/service/registrar_test.py
+++ b/tests/service/registrar_test.py
@@ -108,6 +108,7 @@ class RegistrarTest(DNSimpleTest):
         self.assertEqual('transferring', domain_transfer.state)
         self.assertFalse(domain_transfer.auto_renew)
         self.assertFalse(domain_transfer.whois_privacy)
+        self.assertFalse(domain_transfer.trustee_service)
         self.assertEqual('2016-12-09T19:43:41Z', domain_transfer.created_at)
         self.assertEqual('2016-12-09T19:43:43Z', domain_transfer.updated_at)
 
@@ -140,6 +141,7 @@ class RegistrarTest(DNSimpleTest):
         domain_transfer = self.registrar.get_domain_transfer(1010, 'ruby.codes', 358).data
 
         self.assertEqual('cancelled', domain_transfer.state)
+        self.assertFalse(domain_transfer.trustee_service)
 
     @responses.activate
     def test_cancel_domain_transfer(self):
@@ -149,6 +151,7 @@ class RegistrarTest(DNSimpleTest):
         domain_transfer = self.registrar.cancel_domain_transfer(1010, 'ruby.codes', 358).data
 
         self.assertEqual('transferring', domain_transfer.state)
+        self.assertFalse(domain_transfer.trustee_service)
 
     @responses.activate
     def test_renew_domain(self):


### PR DESCRIPTION
Updated **dnsimple/struct/domain_transfer.py**                                                                                                                                                                                                                                                                 
  - Added trustee_service=None parameter to DomainTransferRequest so callers can opt into the trustee service when initiating a transfer                                                                                                                                                             
  - Added trustee_service = False field to the DomainTransfer response struct so the value is parsed from API responses                                                                                                                                                                              
           
Addresses https://github.com/dnsimple/dnsimple-app/issues/34688
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## :mag: QA

(Optional for reviewers)

✅ From the console (adjust `account_id`, `registrant_id`, `domain_name` and `base_url` accordingly) run this script

```python
import os
import sys

from dnsimple import Client
from dnsimple.struct import DomainTransferRequest

token = os.getenv("TOKEN")
if not token:
    print("ERROR: TOKEN environment variable is required")
    sys.exit(1)

client = Client(
    access_token=token,
    base_url="http://api.dnsimple.localhost:3000",
)

account_id = 2
registrant_id = 27
domain_name = "example.com"

# Transfer a domain with trustee service enabled
transfer = client.registrar.transfer_domain(
    account_id,
    domain_name,
    DomainTransferRequest(
        registrant_id=registrant_id,
        auth_code="x1y2z3",
        trustee_service=True,
    ),
).data
print(f"transfer domain_id={transfer.domain_id} trustee_service={transfer.trustee_service} state={transfer.state}")

# Get the domain transfer to verify
transfer = client.registrar.get_domain_transfer(account_id, domain_name, transfer.id).data
print(f"get_transfer id={transfer.id} trustee_service={transfer.trustee_service} state={transfer.state}")
```

#### QA results

```
dnsimple.exceptions.DNSimpleException: (400)
Reason: Bad Request
HTTP response body: {"message":"TLD .COM does not support trustee service"}
```

```
dnsimple.exceptions.DNSimpleException: (400)
Reason: Bad Request
HTTP response body: {"message":"Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]","errors":{}}
```


## :clipboard: Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version


## :shipit: Deployment Verification

- [x] Verify release is created