### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contact_id` field from the `Certificate` struct and from `LetsencryptCertificateInput`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 7.3.0 - 2026-04-15
 
 ### Added

--- a/dnsimple/struct/certificate.py
+++ b/dnsimple/struct/certificate.py
@@ -2,7 +2,6 @@ import json
 from dataclasses import dataclass
 
 import omitempty
-import warnings
 
 from dnsimple.struct import Struct
 
@@ -15,8 +14,6 @@ class Certificate(Struct):
     """The certificate ID in DNSimple"""
     domain_id = None
     """The associated domain ID"""
-    contact_id = None
-    """The associated contact ID"""
     name = None
     """The certificate name"""
     common_name = None
@@ -61,10 +58,8 @@ class CertificateBundle(Struct):
 
 
 class LetsencryptCertificateInput(dict):
-    def __init__(self, contact_id=None, auto_renew=None, name=None, alternate_names=None, signature_algorithm=None):
+    def __init__(self, auto_renew=None, name=None, alternate_names=None, signature_algorithm=None):
         dict.__init__(self, auto_renew=auto_renew, name=name, alternate_names=alternate_names, signature_algorithm=signature_algorithm)
-        if contact_id is not None:
-            warnings.warn("DEPRECATION WARNING: LetsencryptCertificateInput#contact_id is deprecated and its value is ignored and will be removed in the next major version.")
 
 
     def to_json(self):

--- a/tests/service/certificates_test.py
+++ b/tests/service/certificates_test.py
@@ -37,7 +37,6 @@ class CertificatesTest(DNSimpleTest):
 
         self.assertIsInstance(certificate.id, int)
         self.assertIsInstance(certificate.domain_id, int)
-        self.assertIsInstance(certificate.contact_id, int)
         self.assertEqual('www', certificate.name)
         self.assertEqual('www.bingo.pizza', certificate.common_name)
         self.assertEqual(1, certificate.years)
@@ -150,7 +149,7 @@ class CertificatesTest(DNSimpleTest):
                                            path='/1010/domains/example.com/certificates/letsencrypt',
                                            fixture_name='purchaseLetsencryptCertificate/success'))
         certificate_purchase = self.certificates.purchase_letsencrypt_certificate(1010, 'example.com',
-                                                                                  LetsencryptCertificateInput(42)).data
+                                                                                  LetsencryptCertificateInput()).data
 
         self.assertEqual(101967, certificate_purchase.id)
         self.assertEqual(101967, certificate_purchase.certificate_id)


### PR DESCRIPTION
## Summary

Remove the deprecated `contact_id` field from the `Certificate` struct and from `LetsencryptCertificateInput`. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Tests pass