### PR TITLE
Address security advisories for urllib3 and idna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Security
+
+- Raised the minimum `urllib3` version to `>=2.7.0` to address CVE-2026-44431 and CVE-2026-44432.
+- Raised the minimum `idna` version to `>=3.15` to address CVE-2026-45409.
+
 ## 8.0.0 - 2026-05-05
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ classifiers = [
 python = "^3.12"
 requests = "^2.28.2"
 omitempty = "^0.1.1"
+# Minimum versions for transitive dependencies (pulled in via requests) to
+# pick up security fixes. urllib3 >=2.7.0 covers CVE-2026-44431 and
+# CVE-2026-44432; idna >=3.15 covers CVE-2026-45409.
+urllib3 = ">=2.7.0"
+idna = ">=3.15"
 
 [tool.poetry.group.test.dependencies]
 responses = ">=0.23.1,<0.27.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,7 @@ classifiers = [
 python = "^3.12"
 requests = "^2.28.2"
 omitempty = "^0.1.1"
-# Minimum versions for transitive dependencies (pulled in via requests) to
-# pick up security fixes. urllib3 >=2.7.0 covers CVE-2026-44431 and
-# CVE-2026-44432; idna >=3.15 covers CVE-2026-45409.
+# Minimum versions for transitive dependencies for security
 urllib3 = ">=2.7.0"
 idna = ">=3.15"
 


### PR DESCRIPTION
## Summary

Addresses the open [Dependabot security alerts](https://github.com/dnsimple/dnsimple-python/security/dependabot). All three affect transitive runtime dependencies pulled in via `requests` (they are not used directly in this library), so this raises their minimum versions to the patched releases.

| Severity | Package | Advisory | Fix |
| --- | --- | --- | --- |
| High | urllib3 | [CVE-2026-44432](https://github.com/advisories/GHSA-mf9v-mfxr-j63j): decompression-bomb safeguards bypassed in the streaming API | `>=2.7.0` |
| High | urllib3 | [CVE-2026-44431](https://github.com/advisories/GHSA-qccp-gfcp-xxvc): sensitive headers forwarded across origins in proxied redirects | `>=2.7.0` |
| Medium | idna | [CVE-2026-45409](https://github.com/advisories/GHSA-65pc-fj4g-8rjx): crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix | `>=3.15` |

## Changes

- `pyproject.toml`: add lower-bound constraints `urllib3 >=2.7.0` and `idna >=3.15`.
- `CHANGELOG.md`: add an `Unreleased` / `Security` entry.

## Verification

- `poetry lock` resolves cleanly to `urllib3 2.7.0` and `idna 3.18` (both patched), alongside `requests 2.34.2`.
- Full test suite passes (182 tests).